### PR TITLE
Fix blocking issue in CloudflareApiExecutor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val buildSettings = Seq(
   resolvers ++= Seq(
     Resolver.bintrayIvyRepo("dwolla", "maven"),
   ),
-  scalacOptions += "-deprecation"
+  scalacOptions += "-deprecation",
 )
 
 lazy val bintraySettings = Seq(
@@ -38,6 +38,8 @@ lazy val client = (project in file("client"))
       scalaArm,
       json4s,
       httpComponents,
+      catsCore,
+      catsEffect,
       specs2Core % Test,
       specs2Mock % Test,
       specs2Matchers % Test,

--- a/client/src/main/scala/com/dwolla/cloudflare/CloudflareApiExecutor.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/CloudflareApiExecutor.scala
@@ -7,26 +7,30 @@ import org.apache.http.client.methods.HttpRequestBase
 import org.apache.http.impl.client.{CloseableHttpClient, HttpClients}
 import resource._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent._
 import scala.language.implicitConversions
+import scala.util.Try
 
 class CloudflareApiExecutor(authorization: CloudflareAuthorization)(implicit val ec: ExecutionContext) extends Closeable {
   lazy val httpClient: CloseableHttpClient = HttpClients.createDefault()
+  private def blockingFetch[T]: (HttpRequestBase, HttpResponse ⇒ T) ⇒ Try[T] = CloudflareApiExecutor.blockingFetch[T](authorization, httpClient)
 
-  def fetch[T](request: HttpRequestBase)(f: HttpResponse ⇒ T): Future[T] = {
-    Future.fromTry {
-      request.addHeader("X-Auth-Email", authorization.email)
-      request.addHeader("X-Auth-Key", authorization.key)
-      request.addHeader("Content-Type", "application/json")
-
-      (for {
-        response ← managed(httpClient.execute(request))
-      } yield f(response)).tried
-    }
-
-  }
+  def fetch[T](request: HttpRequestBase)(f: HttpResponse ⇒ T): Future[T] = Future(blocking(blockingFetch(request, f))).flatMap(Future.fromTry)
 
   override def close(): Unit = httpClient.close()
 }
+
+object CloudflareApiExecutor {
+  private[cloudflare] def blockingFetch[T](authorization: CloudflareAuthorization, httpClient: CloseableHttpClient)(request: HttpRequestBase, f: HttpResponse ⇒ T): Try[T] = {
+    request.addHeader("X-Auth-Email", authorization.email)
+    request.addHeader("X-Auth-Key", authorization.key)
+    request.addHeader("Content-Type", "application/json")
+
+    (for {
+      response ← managed(httpClient.execute(request))
+    } yield f(response)).tried
+  }
+}
+
 
 case class CloudflareAuthorization(email: String, key: String)

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/CreateOrUpdate.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/CreateOrUpdate.scala
@@ -1,7 +1,7 @@
 package com.dwolla.cloudflare.domain.model
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.language.{higherKinds, implicitConversions, reflectiveCalls}
+import scala.language.implicitConversions
 
 sealed trait CreateOrUpdate[+A] extends Product with Serializable {
   val value: A

--- a/client/src/test/scala/dwolla/cloudflare/AccountsClientSpec.scala
+++ b/client/src/test/scala/dwolla/cloudflare/AccountsClientSpec.scala
@@ -1,20 +1,19 @@
 package dwolla.cloudflare
 
 import java.net.URI
-import java.time.Instant
-import java.time.format.DateTimeFormatter
 
-import SampleAccountsResponses.Failures
-import com.dwolla.cloudflare.{AccountsClient, CloudflareApiExecutor, CloudflareAuthorization}
+import cats.implicits._
 import com.dwolla.cloudflare.domain.model.accounts._
+import com.dwolla.cloudflare.{AccountsClient, CloudflareAuthorization, _}
+import dwolla.cloudflare.SampleAccountsResponses.Failures
 import dwolla.testutils.httpclient.SimpleHttpRequestMatcher.http
 import org.apache.http.HttpVersion.HTTP_1_1
-import org.apache.http.{HttpEntity, HttpResponse, StatusLine}
 import org.apache.http.client.HttpClient
 import org.apache.http.client.methods._
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.CloseableHttpClient
-import org.apache.http.message.{BasicHttpResponse, BasicStatusLine}
+import org.apache.http.message._
+import org.apache.http._
 import org.json4s.DefaultFormats
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.JsonMatchers
@@ -23,14 +22,14 @@ import org.specs2.mock.mockito.ArgumentCapture
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
-import scala.concurrent.{Future, Promise}
+import scala.concurrent._
 import scala.reflect.ClassTag
 
 class AccountsClientSpec(implicit ee: ExecutionEnv) extends Specification with Mockito with JsonMatchers {
   trait Setup extends Scope {
     implicit val formats = DefaultFormats
     implicit val mockHttpClient = mock[CloseableHttpClient]
-    val fakeExecutor = new CloudflareApiExecutor(CloudflareAuthorization("email", "key")) {
+    val fakeExecutor = new FutureCloudflareApiExecutor(CloudflareAuthorization("email", "key")) {
       override lazy val httpClient: CloseableHttpClient = mockHttpClient
     }
 

--- a/client/src/test/scala/dwolla/cloudflare/CloudflareApiExecutorSpec.scala
+++ b/client/src/test/scala/dwolla/cloudflare/CloudflareApiExecutorSpec.scala
@@ -1,8 +1,9 @@
 package dwolla.cloudflare
 
-import com.dwolla.cloudflare.{CloudflareApiExecutor, CloudflareAuthorization}
+import cats.effect.IO
+import com.dwolla.cloudflare._
 import org.apache.http.HttpResponse
-import org.apache.http.client.methods.{CloseableHttpResponse, HttpRequestBase}
+import org.apache.http.client.methods._
 import org.apache.http.impl.client.CloseableHttpClient
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
@@ -14,14 +15,22 @@ class CloudflareApiExecutorSpec(implicit ee: ExecutionEnv) extends Specification
   trait Setup extends Scope {
     val authorization = CloudflareAuthorization("email", "key")
     val mockHttpClient = mock[CloseableHttpClient]
+  }
 
-    val executor = new CloudflareApiExecutor(authorization) {
+  trait FutureSetup extends Setup {
+    val executor = new FutureCloudflareApiExecutor(authorization) {
       override lazy val httpClient = mockHttpClient
     }
   }
 
-  "Cloudflare API Executor" should {
-    "add required headers to requests" in new Setup {
+  trait AsyncSetup extends Setup {
+    val executor = new AsyncCloudflareApiExecutor[IO](authorization) {
+      override lazy val httpClient = mockHttpClient
+    }
+  }
+
+  "Future-based Cloudflare API Executor" should {
+    "add required headers to requests" in new FutureSetup {
       val request = mock[HttpRequestBase]
       private val response = mock[CloseableHttpResponse]
 
@@ -37,7 +46,31 @@ class CloudflareApiExecutorSpec(implicit ee: ExecutionEnv) extends Specification
       there was one(response).close()
     }
 
-    "close the HttpClient on close" in new Setup {
+    "close the HttpClient on close" in new FutureSetup {
+      executor.close()
+
+      there was one(mockHttpClient).close()
+    }
+  }
+
+  "Async-based Cloudflare API Executor" should {
+    "add required headers to requests" in new AsyncSetup {
+      val request = mock[HttpRequestBase]
+      private val response = mock[CloseableHttpResponse]
+
+      mockHttpClient.execute(request) returns response
+
+      val output = executor.fetch(request)(res ⇒ Option(res)).unsafeToFuture()
+
+      output must beSome(response.asInstanceOf[HttpResponse]).await
+
+      there was one(request).addHeader("X-Auth-Email", authorization.email)
+      there was one(request).addHeader("X-Auth-Key", authorization.key)
+      there was one(request).addHeader("Content-Type", "application/json")
+      there was one(response).close()
+    }
+
+    "close the HttpClient on close" in new AsyncSetup {
       executor.close()
 
       there was one(mockHttpClient).close()

--- a/client/src/test/scala/dwolla/cloudflare/DnsRecordClientSpec.scala
+++ b/client/src/test/scala/dwolla/cloudflare/DnsRecordClientSpec.scala
@@ -19,10 +19,10 @@ import org.specs2.mock.Mockito
 import org.specs2.mock.mockito.ArgumentCapture
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
+import cats.implicits._
 
 import scala.concurrent.Promise
 import scala.io.Source
-import scala.language.reflectiveCalls
 import scala.reflect.ClassTag
 
 class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification with Mockito with JsonMatchers {
@@ -30,7 +30,7 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification with 
   trait Setup extends Scope {
     implicit val formats = DefaultFormats
     implicit val mockHttpClient = mock[CloseableHttpClient]
-    val fakeExecutor = new CloudflareApiExecutor(CloudflareAuthorization("email", "key")) {
+    val fakeExecutor = new FutureCloudflareApiExecutor(CloudflareAuthorization("email", "key")) {
       override lazy val httpClient: CloseableHttpClient = mockHttpClient
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,4 +8,6 @@ object Dependencies {
   val specs2Mock = "org.specs2" %% "specs2-mock" % specs2Core.revision
   val specs2Matchers = "org.specs2" %% "specs2-matcher-extra" % specs2Core.revision
   val dwollaTestUtils = "com.dwolla" %% "testutils" % "1.4.0"
+  val catsCore = "org.typelevel" %% "cats-core" % "1.1.0"
+  val catsEffect = "org.typelevel" %% "cats-effect" % "0.10.1"
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.0-SNAPSHOT"
+version in ThisBuild := "1.3.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.1-SNAPSHOT"
+version in ThisBuild := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
I think this code blocks without shifting to a `Future` first: https://github.com/Dwolla/scala-cloudflare/blob/a39244c52bee481b003f2376317c5fddd8c52a3d/client/src/main/scala/com/dwolla/cloudflare/CloudflareApiExecutor.scala#L17-L25

The first commit in this PR fixes the underlying issue in a non-breaking way, and the second commit proposes an API change that would allow users of the library to execute using cats-effect `IO` instead of `Future`. 

Other than having to construct `CloudflareApiExecutor`, `DnsRecordClient`, and `AccountsClient` slightly differently, I think `Future`-based clients wouldn't be impacted. (They have to use `new FutureCloudflareApiExecutor` instead of `new CloudflareApiExecutor`. The `Future` type should be inferred by the compiler from there.)