### PR TITLE
Add partial support for setting Zone settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,7 @@ lazy val client = (project in file("client"))
         dwollaFs2Utils,
         catsCore,
         catsEffect,
+        shapeless,
       ) ++
       Seq(
         specs2Core,

--- a/client/src/main/scala/com/dwolla/cloudflare/ZoneSettingsClient.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/ZoneSettingsClient.scala
@@ -1,0 +1,75 @@
+package com.dwolla.cloudflare
+
+import _root_.io.circe._
+import _root_.io.circe.generic.auto._
+import _root_.io.circe.syntax._
+import cats._
+import cats.data.Validated._
+import cats.data._
+import cats.effect._
+import cats.implicits._
+import fs2._
+import _root_.org.http4s.circe._
+import com.dwolla.cloudflare.CloudflareSettingFunctions._
+import com.dwolla.cloudflare.domain.dto.ZoneSettingsDTO
+import com.dwolla.cloudflare.domain.model.ZoneSettings._
+import com.dwolla.cloudflare.domain.model._
+import org.http4s.Method._
+import org.http4s.Uri
+import org.http4s.client.dsl.Http4sClientDsl
+
+import scala.concurrent.ExecutionContext
+
+trait ZoneSettingsClient[F[_]] {
+  def updateSettings(domain: Zone): Stream[F, ValidatedNel[Throwable, Unit]]
+}
+
+object ZoneSettingsClient {
+  def apply[F[_] : Effect](executor: StreamingCloudflareApiExecutor[F], maxConcurrency: Int = 5)
+                          (implicit ec: ExecutionContext): ZoneSettingsClient[F] =
+    new ZoneSettingsClientImpl(executor, maxConcurrency)
+}
+
+object CloudflareSettingFunctions {
+  /**
+    * Given a Zone and a Zone ID, return a Some((Uri, Json)) if the
+    * setting should be updated, or a None if it should not.
+    */
+  type CloudflareSettingFunction = Zone ⇒ String ⇒ Option[(Uri, Json)]
+
+  val setTlsLevel: CloudflareSettingFunction = zone ⇒ zoneId ⇒ Option((BaseUrl / "zones" / zoneId / "settings" / "ssl", zone.tlsLevel.asJson))
+
+  val setSecurityLevel: CloudflareSettingFunction =
+    zone ⇒ zoneId ⇒ zone.securityLevel.map(sl ⇒ (BaseUrl / "zones" / zoneId / "settings" / "security_level", sl.asJson))
+
+  val allSettings: Set[CloudflareSettingFunction] = Set(setTlsLevel, setSecurityLevel)
+}
+
+class ZoneSettingsClientImpl[F[_] : Effect](executor: StreamingCloudflareApiExecutor[F], maxConcurrency: Int)
+                                           (implicit ec: ExecutionContext) extends ZoneSettingsClient[F] with Http4sClientDsl[F] {
+  implicit private val nelSemigroup: Semigroup[NonEmptyList[Throwable]] =
+    SemigroupK[NonEmptyList].algebra[Throwable]
+
+  private val dnsRecordClient = DnsRecordClient(executor)
+
+  val settings: Set[CloudflareSettingFunction] = allSettings
+
+  override def updateSettings(zone: Zone): Stream[F, ValidatedNel[Throwable, Unit]] = {
+    for {
+      zoneId ← dnsRecordClient.getZoneId(zone.name)
+      res ← applySettings(zoneId, zone).map(_.attempt).join(maxConcurrency)
+    } yield res.toValidatedNel
+  }.foldMonoid
+
+  private def applySettings(zoneId: String, zone: Zone): Stream[F, Stream[F, Unit]] = {
+    Stream.emits(settings.toList).map(_(zone)(zoneId)).collect {
+      case Some((uri, zoneSetting)) ⇒ patchValue(uri, zoneSetting)
+    }
+  }
+
+  private def patchValue[T](uri: Uri, cloudflareSettingValue: Json) =
+    for {
+      req ← Stream.eval(PATCH(uri, cloudflareSettingValue))
+      _ ← executor.fetch[ZoneSettingsDTO](req)
+    } yield ()
+}

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/ZoneSettings.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/ZoneSettings.scala
@@ -1,0 +1,51 @@
+package com.dwolla.cloudflare.domain.model
+
+import com.dwolla.cloudflare.domain.model.ZoneSettings._
+import io.circe._
+import io.circe.generic.auto._
+
+object ZoneSettings {
+  sealed trait CloudflareTlsLevel
+
+  case object Off extends CloudflareTlsLevel
+  case object FlexibleTls extends CloudflareTlsLevel
+  case object FullTls extends CloudflareTlsLevel
+  case object FullTlsStrict extends CloudflareTlsLevel
+  case object StrictTlsOnlyOriginPull extends CloudflareTlsLevel
+
+  implicit val CloudflareTlsLevelEncoder: Encoder[CloudflareTlsLevel] =
+    encoderBuilder[CloudflareTlsLevel] {
+      case Off ⇒ "off"
+      case FlexibleTls ⇒ "flexible"
+      case FullTls ⇒ "full"
+      case FullTlsStrict ⇒ "strict"
+      case StrictTlsOnlyOriginPull ⇒ "origin_pull"
+    }
+
+  sealed trait CloudflareSecurityLevel
+
+  case object EssentiallyOff extends CloudflareSecurityLevel
+  case object Low extends CloudflareSecurityLevel
+  case object Medium extends CloudflareSecurityLevel
+  case object High extends CloudflareSecurityLevel
+  case object UnderAttack extends CloudflareSecurityLevel
+
+  implicit val CloudflareSecurityLevelEncoder: Encoder[CloudflareSecurityLevel] =
+    encoderBuilder[CloudflareSecurityLevel] {
+      case EssentiallyOff ⇒ "essentially_off"
+      case Low ⇒ "low"
+      case Medium ⇒ "medium"
+      case High ⇒ "high"
+      case UnderAttack ⇒ "under_attack"
+    }
+
+  private def encoderBuilder[T](f: T ⇒ String): Encoder[T] = Encoder[CloudflareSettingValue].contramap(f.andThen(CloudflareSettingValue))
+
+  case class CloudflareSettingValue(value: String)
+
+}
+
+case class Zone(name: String,
+                tlsLevel: CloudflareTlsLevel,
+                securityLevel: Option[CloudflareSecurityLevel],
+               )

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/package.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/package.scala
@@ -1,0 +1,15 @@
+package com.dwolla.cloudflare.domain
+
+import shapeless.tag._
+
+package object model {
+
+  type ZoneId = String @@ ZoneIdTag
+
+  private[cloudflare] val tagZoneId: String ⇒ ZoneId = shapeless.tag[ZoneIdTag][String]
+
+}
+
+package model {
+  trait ZoneIdTag
+}

--- a/client/src/test/scala/dwolla/cloudflare/ZoneSettingsClientSpec.scala
+++ b/client/src/test/scala/dwolla/cloudflare/ZoneSettingsClientSpec.scala
@@ -1,0 +1,127 @@
+package dwolla.cloudflare
+
+import cats.data._
+import cats.effect._
+import cats.implicits._
+import com.dwolla.cloudflare.CloudflareSettingFunctions._
+import com.dwolla.cloudflare._
+import com.dwolla.cloudflare.domain.model._
+import org.http4s._
+import org.http4s.client._
+import org.http4s.dsl.Http4sDsl
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import fs2._
+
+class ZoneSettingsClientSpec(implicit ee: ExecutionEnv) extends Specification {
+
+  private val authorization = CloudflareAuthorization("email", "key")
+  private val fakeCloudflareService = new FakeCloudflareService(authorization)
+  private val getZoneId = fakeCloudflareService.listZones("hydragents.xyz", SampleResponses.Successes.getZones)
+
+  trait Setup extends Scope with Http4sDsl[IO] {
+    def client(csfs: CloudflareSettingFunction*) =
+      for {
+        fakeExecutor ← Reader((fakeService: HttpService[IO]) ⇒ new StreamingCloudflareApiExecutor[IO](Client.fromHttpService(fakeService), authorization))
+      } yield new ZoneSettingsClientImpl(fakeExecutor, 1) {
+        override val settings = csfs.toSet
+      }
+  }
+
+  "Zone Settings client" should {
+
+    "apply the TLS setting to the given domain" in new Setup {
+
+      val zone = Zone("hydragents.xyz", ZoneSettings.FullTlsStrict, None)
+
+      private val zoneSettingsClient = client(setTlsLevel)(getZoneId <+> fakeCloudflareService.setTlsLevelService("fake-zone-id", "strict"))
+      private val output = zoneSettingsClient.updateSettings(zone)
+
+      output.compile.last.unsafeToFuture() must beSome[ValidatedNel[Throwable, Unit]].like {
+        case Validated.Valid(u) ⇒ u must_==(())
+        case Validated.Invalid(e) ⇒ throw e.head
+      }.await
+    }
+
+    "apply the security level to the given domain" in new Setup {
+      val zone = Zone("hydragents.xyz", ZoneSettings.FullTlsStrict, Option(ZoneSettings.High))
+
+      private val zoneSettingsClient = client(setSecurityLevel)(getZoneId <+> fakeCloudflareService.setSecurityLevelService("fake-zone-id", "high"))
+      private val output = zoneSettingsClient.updateSettings(zone)
+
+      output.compile.last.unsafeToFuture() must beSome[ValidatedNel[Throwable, Unit]].like {
+        case Validated.Valid(u) ⇒ u must_==(())
+      }.await
+    }
+
+    "ignore security level if it's not set (indicating a custom setting)" in new Setup {
+      val zone = Zone("hydragents.xyz", ZoneSettings.FullTlsStrict, None)
+
+      private val zoneSettingsClient = client(setSecurityLevel)(getZoneId)
+      private val output = zoneSettingsClient.updateSettings(zone)
+
+      output.compile.last.unsafeToFuture() must beSome[ValidatedNel[Throwable, Unit]].like {
+        case Validated.Valid(u) ⇒ u must_==(())
+      }.await
+    }
+
+    "contain the default rules for all zone settings" in new Setup {
+      private val zoneSettingsClient = new ZoneSettingsClientImpl(new StreamingCloudflareApiExecutor[IO](Client.fromHttpService(HttpService.empty), authorization), 1)
+
+      zoneSettingsClient.settings must contain(setSecurityLevel)
+      zoneSettingsClient.settings must contain(setTlsLevel)
+      zoneSettingsClient.settings should have size 2
+    }
+
+    "accumulate multiple errors, should they occur when updating settings" in new Setup {
+      private val zoneSettingsClient = ZoneSettingsClient(new StreamingCloudflareApiExecutor[IO](Client.fromHttpService(getZoneId), authorization))
+      private val zone = Zone("hydragents.xyz", ZoneSettings.FullTlsStrict, Option(ZoneSettings.High))
+
+      private val output = zoneSettingsClient.updateSettings(zone)
+
+      output.compile.last.unsafeToFuture() should beSome[ValidatedNel[Throwable, Unit]].like {
+        case Validated.Invalid(nel) ⇒ nel.toList should have size greaterThanOrEqualTo(2)
+      }.await
+    }
+
+  }
+
+  private object SampleResponses {
+
+    object Successes {
+      val getZones =
+        """{
+          |  "result": [
+          |    {
+          |      "id": "fake-zone-id",
+          |      "name": "hydragents.xyz",
+          |      "status": "active",
+          |      "paused": false,
+          |      "type": "full",
+          |      "development_mode": 0,
+          |      "name_servers": [
+          |        "eric.ns.cloudflare.com",
+          |        "lucy.ns.cloudflare.com"
+          |      ]
+          |    }
+          |  ],
+          |  "result_info": {
+          |    "page": 1,
+          |    "per_page": 20,
+          |    "total_pages": 1,
+          |    "count": 1,
+          |    "total_count": 1
+          |  },
+          |  "success": true,
+          |  "errors": [],
+          |  "messages": []
+          |}
+        """.stripMargin
+
+
+    }
+
+  }
+
+}

--- a/dto/src/main/scala/com/dwolla/cloudflare/domain/dto/ZoneSettingsDTO.scala
+++ b/dto/src/main/scala/com/dwolla/cloudflare/domain/dto/ZoneSettingsDTO.scala
@@ -1,0 +1,7 @@
+package com.dwolla.cloudflare.domain.dto
+
+case class ZoneSettingsDTO(id: String,
+                           value: String,
+                           editable: Option[Boolean],
+                           modified_on: Option[String],
+                          )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,4 +7,5 @@ object Dependencies {
   val catsEffect = "org.typelevel" %% "cats-effect" % "0.10.1"
   val fs2 = "co.fs2" %% "fs2-core" % "0.10.5"
   val dwollaFs2Utils = "com.dwolla" %% "fs2-utils" % "1.0.1"
+  val shapeless = "com.chuusai" %% "shapeless" % "2.3.3"
 }


### PR DESCRIPTION
Add support for setting a few [Zone settings](https://api.cloudflare.com/#zone-settings-properties). Right now it supports setting the TLS mode and security level, but the feature is designed to be easy to add additional settings in the future.

Before this is merged, I want to add a couple more negative tests, but I wanted to get feedback on the design before spending much more time on this.