### PR TITLE
raise an AccessDenied exception in both known access denied scenarios

### DIFF
--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/Exceptions.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/Exceptions.scala
@@ -1,5 +1,6 @@
 package com.dwolla.cloudflare.domain.model
 
+import com.dwolla.cloudflare.domain.dto.ResponseInfoDTO
 import org.http4s.Status
 
 object Exceptions {
@@ -14,4 +15,14 @@ object Exceptions {
   case class UnexpectedCloudflareResponseStatus(status: Status) extends RuntimeException(s"Received $status response from Cloudflare, but don't know how to handle it")
 
   case object RecordAlreadyExists extends RuntimeException("Cloudflare already has a matching record, and refuses to create a new one.")
+
+  case class AccessDenied(errorChain: List[ResponseInfoDTO] = List.empty)
+    extends RuntimeException(s"The given credentials were invalid${
+      if (errorChain.nonEmpty)
+        errorChain
+          .map(ResponseInfoDTO.unapply)
+          .map(e ⇒ s"   - ${e.getOrElse("None")}")
+          .mkString("\n\n  See the following errors:\n", "\n", "\n")
+      else ""
+    }")
 }

--- a/dto/src/main/scala/com/dwolla/cloudflare/domain/dto/Response.scala
+++ b/dto/src/main/scala/com/dwolla/cloudflare/domain/dto/Response.scala
@@ -13,7 +13,8 @@ object BaseResponseDTO {
 
 case class ResponseInfoDTO (
   code: Int,
-  message: String
+  message: String,
+  error_chain: Option[List[ResponseInfoDTO]] = None,
 )
 
 case class ResultInfoDTO (

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.2.0-SNAPSHOT"
+version in ThisBuild := "3.1.1-SNAPSHOT"


### PR DESCRIPTION
Previously we would see an `UnexpectedCloudflareResponseStatus(403)` when Cloudflare rejected a request due to invalid credentials. The API will also reject requests if the `X-Auth-Email` or `X-Auth-Key` headers are not formatted as it expects, but those responses are `400 Bad Request` with some custom error JSON (which resulted in an empty stream returned by our client methods).

After this change, both types of rejections will be mapped to a new `AccessDenied` exception.