### PR TITLE
migrate to executor.fetch instead of executor.raw and tag most ID types

### DIFF
--- a/client/src/main/scala/com/dwolla/cloudflare/AccessControlRuleClient.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/AccessControlRuleClient.scala
@@ -1,15 +1,11 @@
 package com.dwolla.cloudflare
 
-import cats._
 import cats.effect._
 import cats.implicits._
 import com.dwolla.cloudflare.domain.dto.accesscontrolrules.AccessControlRuleDTO
-import com.dwolla.cloudflare.domain.dto.accounts.AccountDTO
-import com.dwolla.cloudflare.domain.model
-import com.dwolla.cloudflare.domain.model.{AccountId, Error, tagAccountId}
-import com.dwolla.cloudflare.domain.model.Exceptions.UnexpectedCloudflareErrorException
 import com.dwolla.cloudflare.domain.model.accesscontrolrules.Implicits._
 import com.dwolla.cloudflare.domain.model.accesscontrolrules._
+import com.dwolla.cloudflare.domain.model.{Implicits ⇒ _, _}
 import io.circe.Json
 import io.circe.generic.auto._
 import io.circe.optics.JsonPath._
@@ -24,10 +20,8 @@ import scala.language.higherKinds
 
 trait AccessControlRuleClient[F[_]] {
   def list(accountId: AccountId, mode: Option[String]): Stream[F, Rule]
-
   def create(accountId: AccountId, rule: CreateRule): Stream[F, Rule]
-
-  def delete(accountId: AccountId, ruleId: String): Stream[F, String]
+  def delete(accountId: AccountId, ruleId: String): Stream[F, AccessControlRuleId]
 }
 
 object AccessControlRuleClient {
@@ -35,65 +29,25 @@ object AccessControlRuleClient {
 }
 
 class AccessControlRuleClientImpl[F[_] : Sync](executor: StreamingCloudflareApiExecutor[F]) extends AccessControlRuleClient[F] with Http4sClientDsl[F] {
-  def list(accountId: AccountId, mode: Option[String]): Stream[F, Rule] =
+  override def list(accountId: AccountId, mode: Option[String]): Stream[F, Rule] =
     for {
       req ← Stream.eval(GET(mode.toSeq.foldLeft(BaseUrl / "accounts" / accountId / "firewall" / "access_rules" / "rules")((uri: Uri, param: String) ⇒ uri.withQueryParam("mode", param))))
       record ← executor.fetch[AccessControlRuleDTO](req)
     } yield Rule(record.id, record.notes, record.allowedModes, record.mode, record.configuration, record.createdOn, record.modifiedOn, record.scope)
 
-  def create(accountId: AccountId, rule: CreateRule): Stream[F, Rule] =
+  override def create(accountId: AccountId, rule: CreateRule): Stream[F, Rule] =
     for {
       req ← Stream.eval(POST(BaseUrl / "accounts" / accountId / "firewall" / "access_rules" / "rules", rule.asJson))
-      resp ← createOrFail(req)
+      resp ← executor.fetch[AccessControlRuleDTO](req).map(Implicits.toModel)
     } yield resp
 
-  def delete(accountId: AccountId, ruleId: String): Stream[F, String] = Stream.eval(deleteF(accountId, ruleId))
-
-  def getAccountId(unverifiedAccountID: String): Stream[F, AccountId] =
-    executor.fetch[AccountDTO](Request[F](uri = BaseUrl / "accounts" / unverifiedAccountID))
-      .map(account => tagAccountId(account.id))
-
-  private def deleteF(accountId: AccountId, ruleId: String): F[String] =
+  override def delete(accountId: AccountId, ruleId: String): Stream[F, AccessControlRuleId] =
     for {
-      req ← DELETE(BaseUrl / "accounts" / accountId / "firewall" / "access_rules" / "rules" / ruleId)
-      id ← executor.raw(req) { res ⇒
-        for {
-          json ← res.decodeJson[Json]
-          output ← handleDeleteResponseJson(json, res.status, accountId, ruleId)
-        } yield output
-      }
-    } yield id
+      req ← Stream.eval(DELETE(BaseUrl / "accounts" / accountId / "firewall" / "access_rules" / "rules" / ruleId))
+      json ← executor.fetch[Json](req).last
+    } yield tagAccessControlRuleId(json.flatMap(deletedRecordLens).getOrElse(ruleId))
 
-  private def handleDeleteResponseJson(json: Json, status: Status, accountId: AccountId, ruleId: String): F[String] =
-    if (status.isSuccess)
-      deletedRecordLens(json).fold(Applicative[F].pure(ruleId))(Applicative[F].pure)
-    else {
-      if (status == Status.NotFound)
-        Sync[F].raiseError(RuleIdDoesNotExistException(accountId, ruleId))
-      else
-        Sync[F].raiseError(UnexpectedCloudflareErrorException(errorsLens(json)))
-    }
-
-  private def createOrFail(request: Request[F]): Stream[F, Rule] = Stream.eval(createOrF(request))
-
-  private def createOrF(request: Request[F]): F[Rule] =
-    executor.raw(request) { res ⇒
-      for {
-        json ← res.decodeJson[Json]
-        output ← handleCreateUpdateResponseJson(json, res.status)
-      } yield output
-    }
-
-  private def handleCreateUpdateResponseJson(json: Json, status: Status): F[Rule] =
-    if (status.isSuccess)
-      Applicative[F].pure(ruleLens(json))
-    else {
-      Sync[F].raiseError(UnexpectedCloudflareErrorException(errorsLens(json)))
-    }
-
-  private val deletedRecordLens: Json ⇒ Option[String] = root.result.id.string.getOption
-  private val ruleLens: Json ⇒ Rule = root.result.as[AccessControlRuleDTO].getOption(_).get
-  private val errorsLens: Json ⇒ List[Error] = root.errors.each.as[model.Error].getAll
+  private val deletedRecordLens: Json ⇒ Option[String] = root.id.string.getOption
 }
 
 case class RuleIdDoesNotExistException(accounId: AccountId, ruleId: String) extends RuntimeException(

--- a/client/src/main/scala/com/dwolla/cloudflare/AccountMembersClient.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/AccountMembersClient.scala
@@ -1,0 +1,88 @@
+package com.dwolla.cloudflare
+
+import cats.effect._
+import cats.implicits._
+import com.dwolla.cloudflare.AccountMembersClientImpl.notFoundCodes
+import com.dwolla.cloudflare.domain.dto.accounts._
+import com.dwolla.cloudflare.domain.model.Exceptions.UnexpectedCloudflareErrorException
+import com.dwolla.cloudflare.domain.model.accounts.Implicits.{toDto, _}
+import com.dwolla.cloudflare.domain.model.accounts._
+import com.dwolla.cloudflare.domain.model.{Implicits ⇒ _, _}
+import io.circe.Json
+import io.circe.generic.auto._
+import io.circe.syntax._
+import io.circe.optics.JsonPath._
+import fs2._
+import org.http4s.Method._
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.client.dsl.Http4sClientDsl
+
+import scala.language.higherKinds
+import scala.util.matching.Regex
+
+trait AccountMembersClient[F[_]] {
+  def getById(accountId: AccountId, memberId: String): Stream[F, AccountMember]
+  def addMember(accountId: AccountId, emailAddress: String, roleIds: List[String]): Stream[F, AccountMember]
+  def updateMember(accountId: AccountId, accountMember: AccountMember): Stream[F, AccountMember]
+  def removeMember(accountId: AccountId, accountMemberId: String): Stream[F, AccountMemberId]
+
+  def getByUri(uri: String): Stream[F, AccountMember] = parseUri(uri).fold(Stream.empty.covaryAll[F, AccountMember]) {
+    case (accountId, memberId) ⇒ getById(accountId, memberId)
+  }
+
+  def parseUri(uri: String): Option[(AccountId, AccountMemberId)] = uri match {
+    case AccountMembersClient.uriRegex(accountId, memberId) ⇒ Option((tagAccountId(accountId), tagAccountMemberId(memberId)))
+    case _ ⇒ None
+  }
+}
+
+object AccountMembersClient {
+  def apply[F[_] : Sync](executor: StreamingCloudflareApiExecutor[F]): AccountMembersClient[F] = new AccountMembersClientImpl[F](executor)
+
+  val uriRegex: Regex = """https://api.cloudflare.com/client/v4/accounts/(.+?)/members/(.+)""".r
+}
+
+class AccountMembersClientImpl[F[_]: Sync](executor: StreamingCloudflareApiExecutor[F]) extends AccountMembersClient[F] with Http4sClientDsl[F] {
+  override def getById(accountId: AccountId, accountMemberId: String): Stream[F, AccountMember] =
+    for {
+      req ← Stream.eval(GET(buildAccountMemberUri(accountId, accountMemberId)))
+      res ← executor.fetch[AccountMemberDTO](req).returningEmptyOnErrorCodes(notFoundCodes: _*)
+    } yield res
+
+  override def addMember(accountId: AccountId, emailAddress: String, roleIds: List[String]): Stream[F, AccountMember] =
+    for {
+      req ← Stream.eval(POST(BaseUrl / "accounts" / accountId / "members", NewAccountMemberDTO(emailAddress, roleIds, Some("pending")).asJson))
+      resp ← createOrUpdate(req)
+    } yield resp
+
+  override def updateMember(accountId: AccountId, accountMember: AccountMember): Stream[F, AccountMember] = {
+    for {
+      req ← Stream.eval(PUT(buildAccountMemberUri(accountId, accountMember.id), toDto(accountMember).asJson))
+      resp ← createOrUpdate(req)
+    } yield resp
+  }
+
+  override def removeMember(accountId: AccountId, accountMemberId: String): Stream[F, AccountMemberId] =
+  /*_*/
+    for {
+      req ← Stream.eval(DELETE(buildAccountMemberUri(accountId, accountMemberId)))
+      json ← executor.fetch[Json](req).last.adaptError {
+        case ex: UnexpectedCloudflareErrorException if ex.errors.flatMap(_.code.toSeq).exists(notFoundCodes.contains) ⇒
+          AccountMemberDoesNotExistException(accountId, accountMemberId)
+      }
+    } yield tagAccountMemberId(json.flatMap(deletedRecordLens).getOrElse(accountMemberId))
+  /*_*/
+
+  private def buildAccountMemberUri(accountId: AccountId, accountMemberId: String): Uri =
+    BaseUrl / "accounts" / accountId / "members" / accountMemberId
+
+  private def createOrUpdate(request: Request[F]): Stream[F, AccountMember] =
+    executor.fetch[AccountMemberDTO](request).map(Implicits.toModel)
+
+  private val deletedRecordLens: Json ⇒ Option[String] = root.id.string.getOption
+}
+
+object AccountMembersClientImpl {
+  val notFoundCodes = List(1003)
+}

--- a/client/src/main/scala/com/dwolla/cloudflare/AccountsClient.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/AccountsClient.scala
@@ -1,15 +1,14 @@
 package com.dwolla.cloudflare
 
-import cats._
 import cats.effect._
 import cats.implicits._
+import com.dwolla.cloudflare.AccountsClientImpl._
 import com.dwolla.cloudflare.domain.dto.accounts._
-import com.dwolla.cloudflare.domain.model
-import com.dwolla.cloudflare.domain.model.Error
 import com.dwolla.cloudflare.domain.model.Exceptions.UnexpectedCloudflareErrorException
 import com.dwolla.cloudflare.domain.model.accounts.Implicits._
 import com.dwolla.cloudflare.domain.model.accounts._
-import io.circe._
+import com.dwolla.cloudflare.domain.model.{Implicits ⇒ _, _}
+import io.circe.Json
 import io.circe.generic.auto._
 import io.circe.optics.JsonPath._
 import io.circe.syntax._
@@ -25,113 +24,88 @@ trait AccountsClient[F[_]] {
   def list(): Stream[F, Account]
   def getById(accountId: String): Stream[F, Account]
   def getByName(name: String): Stream[F, Account]
-  def listRoles(accountId: String): Stream[F, AccountRole]
-  def getMember(accountId: String, accountMemberId: String): Stream[F, AccountMember]
-  def addMember(accountId: String, emailAddress: String, roleIds: List[String]): Stream[F, AccountMember]
-  def updateMember(accountId: String, accountMember: AccountMember): Stream[F, AccountMember]
-  def removeMember(accountId: String, accountMemberId: String): Stream[F, String]
+  def listRoles(accountId: AccountId): Stream[F, AccountRole]
+  def getMember(accountId: AccountId, accountMemberId: String): Stream[F, AccountMember]
+  def addMember(accountId: AccountId, emailAddress: String, roleIds: List[String]): Stream[F, AccountMember]
+  def updateMember(accountId: AccountId, accountMember: AccountMember): Stream[F, AccountMember]
+  def removeMember(accountId: AccountId, accountMemberId: String): Stream[F, AccountMemberId]
 }
 
 object AccountsClient {
   def apply[F[_] : Sync](executor: StreamingCloudflareApiExecutor[F]): AccountsClient[F] = new AccountsClientImpl[F](executor)
 }
 
+object AccountsClientImpl {
+  val notFoundCodes = List(1003)
+}
+
 class AccountsClientImpl[F[_]: Sync](executor: StreamingCloudflareApiExecutor[F]) extends AccountsClient[F] with Http4sClientDsl[F] {
-  def list(): Stream[F, Account] = {
+  override def list(): Stream[F, Account] = {
     for {
       req ← Stream.eval(GET(BaseUrl / "accounts" withQueryParam("direction", "asc")))
       record ← executor.fetch[AccountDTO](req)
     } yield record
   }
 
-  def getById(accountId: String): Stream[F, Account] =
+  override def getById(accountId: String): Stream[F, Account] =
     for {
       req ← Stream.eval(GET(BaseUrl / "accounts" / accountId))
-      res ← executor.fetch[AccountDTO](req)
+      res ← executor.fetch[AccountDTO](req).returningEmptyOnErrorCodes(notFoundCodes: _*)
     } yield res
 
-  def getByName(name: String): Stream[F, Account] = {
+  override def getByName(name: String): Stream[F, Account] = {
     list()
       .filter(a ⇒ a.name.toUpperCase == name.toUpperCase)
   }
 
-  def listRoles(accountId: String): Stream[F, AccountRole] = {
+  override def listRoles(accountId: AccountId): Stream[F, AccountRole] = {
     for {
       req ← Stream.eval(GET(BaseUrl / "accounts" / accountId / "roles"))
       record ← executor.fetch[AccountRoleDTO](req)
     } yield record
   }
 
-  def getMember(accountId: String, accountMemberId: String): Stream[F, AccountMember] =
+  override def getMember(accountId: AccountId, accountMemberId: String): Stream[F, AccountMember] =
     for {
       req ← Stream.eval(GET(buildAccountMemberUri(accountId, accountMemberId)))
-      res ← executor.fetch[AccountMemberDTO](req)
+      res ← executor.fetch[AccountMemberDTO](req).returningEmptyOnErrorCodes(notFoundCodes: _*)
     } yield res
 
-  def addMember(accountId: String, emailAddress: String, roleIds: List[String]): Stream[F, AccountMember] = {
+  override def addMember(accountId: AccountId, emailAddress: String, roleIds: List[String]): Stream[F, AccountMember] =
     for {
-      dto ← Stream.eval(Applicative[F].pure(NewAccountMemberDTO(emailAddress, roleIds, Some("pending"))))
-      req ← Stream.eval(POST(BaseUrl / "accounts" / accountId / "members", dto.asJson))
+      req ← Stream.eval(POST(BaseUrl / "accounts" / accountId / "members", NewAccountMemberDTO(emailAddress, roleIds, Some("pending")).asJson))
       resp ← createOrUpdate(req)
     } yield resp
-  }
 
-  def updateMember(accountId: String, accountMember: AccountMember): Stream[F, AccountMember] = {
+  override def updateMember(accountId: AccountId, accountMember: AccountMember): Stream[F, AccountMember] = {
     for {
       req ← Stream.eval(PUT(buildAccountMemberUri(accountId, accountMember.id), toDto(accountMember).asJson))
       resp ← createOrUpdate(req)
     } yield resp
   }
 
-  def removeMember(accountId: String, accountMemberId: String): Stream[F, String] = Stream.eval(removeMemberF(accountId, accountMemberId))
+  override def removeMember(accountId: AccountId, accountMemberId: String): Stream[F, AccountMemberId] =
+  /*_*/
+    for {
+      req ← Stream.eval(DELETE(buildAccountMemberUri(accountId, accountMemberId)))
+      json ← executor.fetch[Json](req).last.adaptError {
+        case ex: UnexpectedCloudflareErrorException if ex.errors.flatMap(_.code.toSeq).exists(notFoundCodes.contains) ⇒
+          AccountMemberDoesNotExistException(accountId, accountMemberId)
+      }
+    } yield tagAccountMemberId(json.flatMap(deletedRecordLens).getOrElse(accountMemberId))
+  /*_*/
 
-  private def buildAccountMemberUri(accountId: String, accountMemberId: String): Uri =
+  private def buildAccountMemberUri(accountId: AccountId, accountMemberId: String): Uri =
     BaseUrl / "accounts" / accountId / "members" / accountMemberId
 
-  private def createOrUpdate(request: Request[F]): Stream[F, AccountMember] = Stream.eval(createOrUpdateF(request))
-
-  private def createOrUpdateF(request: Request[F]): F[AccountMember] = {
-    executor.raw(request) { res ⇒
-      for {
-        json ← res.decodeJson[Json]
-        output ← handleCreateUpdateResponseJson(json, res.status)
-      } yield output
-    }
-  }
-
-  private def removeMemberF(accountId: String, accountMemberId: String): F[String] =
+  private def createOrUpdate(request: Request[F]): Stream[F, AccountMember] =
     for {
-      req ← DELETE(buildAccountMemberUri(accountId, accountMemberId))
-      id ← executor.raw(req) { res ⇒
-        for {
-          json ← res.decodeJson[Json]
-          output ← handleDeleteResponseJson(json, res.status, accountId, accountMemberId)
-        } yield output
-      }
-    } yield id
+      res ← executor.fetch[AccountMemberDTO](request)
+    } yield res
 
-  private def handleDeleteResponseJson(json: Json, status: Status, accountId: String, accountMemberId: String): F[String] =
-    if (status.isSuccess)
-      deletedRecordLens(json).fold(Applicative[F].pure(accountMemberId))(Applicative[F].pure)
-    else {
-      if (status == Status.NotFound)
-        Sync[F].raiseError(AccountMemberDoesNotExistException(accountId, accountMemberId))
-      else
-        Sync[F].raiseError(UnexpectedCloudflareErrorException(errorsLens(json)))
-    }
-
-  private def handleCreateUpdateResponseJson(json: Json, status: Status): F[AccountMember] =
-    if (status.isSuccess)
-      Applicative[F].pure(accountMemberLens(json))
-    else {
-      Sync[F].raiseError(UnexpectedCloudflareErrorException(errorsLens(json)))
-    }
-
-  private val deletedRecordLens: Json ⇒ Option[String] = root.result.id.string.getOption
-  private val accountMemberLens: Json ⇒ AccountMember = root.result.as[AccountMemberDTO].getOption(_).get
-  private val errorsLens: Json ⇒ List[Error] = root.errors.each.as[model.Error].getAll
+  private val deletedRecordLens: Json ⇒ Option[String] = root.id.string.getOption
 }
 
-case class AccountMemberDoesNotExistException(accountId: String, accountMemberId: String) extends RuntimeException(
+case class AccountMemberDoesNotExistException(accountId: AccountId, accountMemberId: String) extends RuntimeException(
   s"The account member $accountMemberId not found for account $accountId."
 )

--- a/client/src/main/scala/com/dwolla/cloudflare/RateLimitClient.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/RateLimitClient.scala
@@ -31,7 +31,7 @@ trait RateLimitClient[F[_]] {
   }
 
   def parseUri(uri: String): Option[(ZoneId, RateLimitId)] = uri match {
-    case RateLimitClient.rateLimitUriRegex(zoneId, rateLimitId) ⇒ Option((tagZoneId(zoneId), tagRateLimitId(rateLimitId)))
+    case RateLimitClient.uriRegex(zoneId, rateLimitId) ⇒ Option((tagZoneId(zoneId), tagRateLimitId(rateLimitId)))
     case _ ⇒ None
   }
 }
@@ -39,7 +39,7 @@ trait RateLimitClient[F[_]] {
 object RateLimitClient {
   def apply[F[_] : Sync](executor: StreamingCloudflareApiExecutor[F]): RateLimitClient[F] = new RateLimitClientImpl[F](executor)
 
-  val rateLimitUriRegex: Regex = """https://api.cloudflare.com/client/v4/zones/(.+?)/rate_limits/(.+)""".r
+  val uriRegex: Regex = """https://api.cloudflare.com/client/v4/zones/(.+?)/rate_limits/(.+)""".r
 }
 
 object RateLimitClientImpl {

--- a/client/src/main/scala/com/dwolla/cloudflare/RateLimitClient.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/RateLimitClient.scala
@@ -1,12 +1,10 @@
 package com.dwolla.cloudflare
 
-import cats._
 import cats.effect._
 import cats.implicits._
 import com.dwolla.cloudflare.domain.dto.ratelimits._
-import com.dwolla.cloudflare.domain.model
-import com.dwolla.cloudflare.domain.model.{Error, _}
 import com.dwolla.cloudflare.domain.model.Exceptions.UnexpectedCloudflareErrorException
+import com.dwolla.cloudflare.domain.model.{Implicits ⇒ _, _}
 import com.dwolla.cloudflare.domain.model.ratelimits.Implicits._
 import com.dwolla.cloudflare.domain.model.ratelimits._
 import io.circe.generic.auto._
@@ -15,114 +13,97 @@ import io.circe.syntax._
 import io.circe.{Decoder, DecodingFailure, HCursor, Json}
 import fs2._
 import org.http4s.Method._
-import org.http4s._
 import org.http4s.circe._
 import org.http4s.client.dsl.Http4sClientDsl
 
 import scala.language.higherKinds
+import scala.util.matching.Regex
 
 trait RateLimitClient[F[_]] {
   def list(zoneId: ZoneId): Stream[F, RateLimit]
-  def getById(zoneId: ZoneId, rateLimitId: RateLimitId): Stream[F, RateLimit]
+  def getById(zoneId: ZoneId, rateLimitId: String): Stream[F, RateLimit]
   def create(zoneId: ZoneId, rateLimit: CreateRateLimit): Stream[F, RateLimit]
   def update(zoneId: ZoneId, rateLimit: RateLimit): Stream[F, RateLimit]
-  def delete(zoneId: ZoneId, rateLimitId: RateLimitId): Stream[F, RateLimitId]
+  def delete(zoneId: ZoneId, rateLimitId: String): Stream[F, RateLimitId]
+
+  def getByUri(uri: String): Stream[F, RateLimit] = parseUri(uri).fold(Stream.empty.covaryAll[F, RateLimit]) {
+    case (zoneId, rateLimitId) ⇒ getById(zoneId, rateLimitId)
+  }
+
+  def parseUri(uri: String): Option[(ZoneId, RateLimitId)] = uri match {
+    case RateLimitClient.rateLimitUriRegex(zoneId, rateLimitId) ⇒ Option((tagZoneId(zoneId), tagRateLimitId(rateLimitId)))
+    case _ ⇒ None
+  }
 }
 
 object RateLimitClient {
   def apply[F[_] : Sync](executor: StreamingCloudflareApiExecutor[F]): RateLimitClient[F] = new RateLimitClientImpl[F](executor)
+
+  val rateLimitUriRegex: Regex = """https://api.cloudflare.com/client/v4/zones/(.+?)/rate_limits/(.+)""".r
+}
+
+object RateLimitClientImpl {
+  val notFoundCodes = List(10001)
 }
 
 class RateLimitClientImpl[F[_] : Sync](executor: StreamingCloudflareApiExecutor[F]) extends RateLimitClient[F] with Http4sClientDsl[F] {
-  implicit val rateLimitActionDtoDecoder: Decoder[RateLimitActionDTO] = new Decoder[RateLimitActionDTO] {
-    override def apply(c: HCursor): Decoder.Result[RateLimitActionDTO] =
-      for {
-        mode ← c.downField("mode").as[String]
-        timeout ← c.downField("timeout").as[Option[Int]]
-        response ← c.downField("response").as[Option[RateLimitActionResponseDTO]]
-        dto ← (mode, timeout) match {
-          case ("challenge", None) ⇒ Right(ChallengeRateLimitActionDTO)
-          case ("js_challenge", None) ⇒ Right(JsChallengeRateLimitActionDTO)
-          case ("ban", Some(t)) ⇒ Right(BanRateLimitActionDTO(t, response))
-          case ("simulate", Some(t)) ⇒ Right(SimulateRateLimitActionDTO(t, response))
-          case _ ⇒ Left(DecodingFailure("Invalid mode for rate limit action", c.history))
-        }
-      } yield dto
-  }
+  import RateLimitClientImpl._
 
-  def list(zoneId: ZoneId): Stream[F, RateLimit] = {
+  implicit val rateLimitActionDtoDecoder: Decoder[RateLimitActionDTO] =
+    (c: HCursor) ⇒ for {
+      mode ← c.downField("mode").as[String]
+      timeout ← c.downField("timeout").as[Option[Int]]
+      response ← c.downField("response").as[Option[RateLimitActionResponseDTO]]
+      dto ← (mode, timeout) match {
+        case ("challenge", None) ⇒ Right(ChallengeRateLimitActionDTO)
+        case ("js_challenge", None) ⇒ Right(JsChallengeRateLimitActionDTO)
+        case ("ban", Some(t)) ⇒ Right(BanRateLimitActionDTO(t, response))
+        case ("simulate", Some(t)) ⇒ Right(SimulateRateLimitActionDTO(t, response))
+        case _ ⇒ Left(DecodingFailure("Invalid mode for rate limit action", c.history))
+      }
+    } yield dto
+
+  override def list(zoneId: ZoneId): Stream[F, RateLimit] = {
     for {
       req ← Stream.eval(GET(BaseUrl / "zones" / zoneId / "rate_limits"))
       record ← executor.fetch[RateLimitDTO](req)
     } yield record
   }
 
-  def getById(zoneId: ZoneId, rateLimitId: RateLimitId): Stream[F, RateLimit] =
+  override def getById(zoneId: ZoneId, rateLimitId: String): Stream[F, RateLimit] =
     for {
       req ← Stream.eval(GET(BaseUrl / "zones" / zoneId / "rate_limits" / rateLimitId))
-      res ← executor.fetch[RateLimitDTO](req)
+      res ← executor.fetch[RateLimitDTO](req).returningEmptyOnErrorCodes(notFoundCodes: _*)
     } yield res
 
-  def create(zoneId: ZoneId, rateLimit: CreateRateLimit): Stream[F, RateLimit] = {
+  override def create(zoneId: ZoneId, rateLimit: CreateRateLimit): Stream[F, RateLimit] = {
     for {
       req ← Stream.eval(POST(BaseUrl / "zones" / zoneId / "rate_limits", rateLimit.asJson))
-      resp ← createOrUpdate(req)
+      resp ← executor.fetch[RateLimitDTO](req).map(Implicits.toModel)
     } yield resp
   }
 
-  def update(zoneId: ZoneId, rateLimit: RateLimit): Stream[F, RateLimit] = {
+  override def update(zoneId: ZoneId, rateLimit: RateLimit): Stream[F, RateLimit] = {
     for {
       req ← Stream.eval(PUT(BaseUrl / "zones" / zoneId / "rate_limits" / rateLimit.id, toDto(rateLimit).asJson))
-      resp ← createOrUpdate(req)
+      resp ← executor.fetch[RateLimitDTO](req).map(Implicits.toModel)
     } yield resp
   }
 
-  def delete(zoneId: ZoneId, rateLimitId: RateLimitId): Stream[F, RateLimitId] = Stream.eval(deleteF(zoneId, rateLimitId))
-
-  private def deleteF(zoneId: ZoneId, rateLimitId: RateLimitId): F[RateLimitId] =
+  override def delete(zoneId: ZoneId, rateLimitId: String): Stream[F, RateLimitId] =
+  /*_*/
     for {
-      req ← DELETE(BaseUrl / "zones" / zoneId / "rate_limits" / rateLimitId)
-      id ← executor.raw(req) { res ⇒
-        for {
-          json ← res.decodeJson[Json]
-          output ← handleDeleteResponseJson(json, res.status, zoneId, rateLimitId)
-        } yield output
+      req ← Stream.eval(DELETE(BaseUrl / "zones" / zoneId / "rate_limits" / rateLimitId))
+      json ← executor.fetch[Json](req).last.adaptError {
+        case ex: UnexpectedCloudflareErrorException if ex.errors.flatMap(_.code.toSeq).exists(notFoundCodes.contains) ⇒
+          RateLimitDoesNotExistException(zoneId, rateLimitId)
       }
-    } yield id
+    } yield tagRateLimitId(json.flatMap(deletedRecordLens).getOrElse(rateLimitId))
+  /*_*/
 
-  private def handleDeleteResponseJson(json: Json, status: Status, zoneId: ZoneId, rateLimitId: RateLimitId): F[RateLimitId] =
-    if (status.isSuccess)
-      deletedRecordLens(json).fold(Applicative[F].pure(rateLimitId))(Applicative[F].pure)
-    else {
-      if (status == Status.NotFound)
-        Sync[F].raiseError(RateLimitDoesNotExistException(zoneId, rateLimitId))
-      else
-        Sync[F].raiseError(UnexpectedCloudflareErrorException(errorsLens(json)))
-    }
-
-  private def createOrUpdate(request: Request[F]): Stream[F, RateLimit] = Stream.eval(createOrUpdateF(request))
-
-  private def createOrUpdateF(request: Request[F]): F[RateLimit] = {
-    executor.raw(request) { res ⇒
-      for {
-        json ← res.decodeJson[Json]
-        output ← handleCreateUpdateResponseJson(json, res.status)
-      } yield output
-    }
-  }
-
-  private def handleCreateUpdateResponseJson(json: Json, status: Status): F[RateLimit] =
-    if (status.isSuccess)
-      Applicative[F].pure(rateLimitLens(json))
-    else {
-      Sync[F].raiseError(UnexpectedCloudflareErrorException(errorsLens(json)))
-    }
-
-  private val deletedRecordLens: Json ⇒ Option[RateLimitId] = root.result.id.string.getOption(_).map(tagRateLimitId)
-  private val rateLimitLens: Json ⇒ RateLimit = root.result.as[RateLimitDTO].getOption(_).get
-  private val errorsLens: Json ⇒ List[Error] = root.errors.each.as[model.Error].getAll
+  private val deletedRecordLens: Json ⇒ Option[String] = root.id.string.getOption
 }
 
-case class RateLimitDoesNotExistException(zoneId: ZoneId, rateLimitId: RateLimitId) extends RuntimeException(
+case class RateLimitDoesNotExistException(zoneId: ZoneId, rateLimitId: String) extends RuntimeException(
   s"The rate limit $rateLimitId not found for zone $zoneId."
 )

--- a/client/src/main/scala/com/dwolla/cloudflare/ZoneClient.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/ZoneClient.scala
@@ -1,0 +1,27 @@
+package com.dwolla.cloudflare
+
+import _root_.io.circe.generic.auto._
+import cats.effect._
+import com.dwolla.cloudflare.domain.dto.dns._
+import com.dwolla.cloudflare.domain.model._
+import fs2._
+import org.http4s._
+
+import scala.language.higherKinds
+
+trait ZoneClient[F[_]] {
+  def getZoneId(domain: String): Stream[F, ZoneId]
+}
+
+object ZoneClient {
+  def apply[F[_] : Sync](executor: StreamingCloudflareApiExecutor[F]): ZoneClient[F] = new ZoneClientImpl[F](executor)
+}
+
+class ZoneClientImpl[F[_] : Sync](executor: StreamingCloudflareApiExecutor[F]) extends ZoneClient[F] {
+  override def getZoneId(domain: String): Stream[F, ZoneId] =
+    executor.fetch[ZoneDTO](Request[F](uri = BaseUrl / "zones" +? ("name", domain) +? ("status", "active")))
+      .map(_.id)
+      .collect {
+        case Some(id) ⇒ tagZoneId(id)
+      }
+}

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/DnsRecord.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/DnsRecord.scala
@@ -1,4 +1,6 @@
-package com.dwolla.cloudflare.domain.model
+package com.dwolla.cloudflare
+package domain
+package model
 
 import com.dwolla.cloudflare.domain.dto.dns.DnsRecordDTO
 
@@ -25,25 +27,14 @@ case class UnidentifiedDnsRecord(name: String,
   import IdentifiedDnsRecord._
 
   def identifyAs(physicalResourceId: String): IdentifiedDnsRecord = physicalResourceId match {
-    case dnsRecordIdUrlRegex(zoneId, recordId) ⇒
-      IdentifiedDnsRecord(
-        physicalResourceId = s"https://api.cloudflare.com/client/v4/zones/$zoneId/dns_records/$recordId",
-        zoneId = zoneId,
-        resourceId = recordId,
-        name = this.name,
-        content = this.content,
-        recordType = this.recordType,
-        ttl = this.ttl,
-        proxied = this.proxied,
-        priority = this.priority,
-      )
+    case dnsRecordIdUrlRegex(zoneId, recordId) ⇒ identifyAs(zoneId, recordId)
     case _ ⇒ throw new RuntimeException("Passed string does not match URL pattern for Cloudflare DNS record")
   }
 
   def identifyAs(zoneId: String, recordId: String): IdentifiedDnsRecord = IdentifiedDnsRecord(
-    physicalResourceId = s"https://api.cloudflare.com/client/v4/zones/$zoneId/dns_records/$recordId",
-    zoneId = zoneId,
-    resourceId = recordId,
+    physicalResourceId = tagPhysicalResourceId(s"https://api.cloudflare.com/client/v4/zones/$zoneId/dns_records/$recordId"),
+    zoneId = tagZoneId(zoneId),
+    resourceId = tagResourceId(recordId),
     name = this.name,
     content = this.content,
     recordType = this.recordType,
@@ -54,9 +45,9 @@ case class UnidentifiedDnsRecord(name: String,
 
 }
 
-case class IdentifiedDnsRecord(physicalResourceId: String,
-                               zoneId: String,
-                               resourceId: String,
+case class IdentifiedDnsRecord(physicalResourceId: PhysicalResourceId,
+                               zoneId: ZoneId,
+                               resourceId: ResourceId,
                                name: String,
                                content: String,
                                recordType: String,

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/accesscontrolrules/AccessControlRule.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/accesscontrolrules/AccessControlRule.scala
@@ -1,6 +1,8 @@
 package com.dwolla.cloudflare.domain.model.accesscontrolrules
 
-case class Rule(id: String,
+import com.dwolla.cloudflare.domain.model.AccessControlRuleId
+
+case class Rule(id: AccessControlRuleId,
                 notes: Option[String],
                 allowedModes: List[String],
                 mode: Option[String],

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/accesscontrolrules/Implicits.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/accesscontrolrules/Implicits.scala
@@ -1,11 +1,12 @@
 package com.dwolla.cloudflare.domain.model.accesscontrolrules
 
 import com.dwolla.cloudflare.domain.dto.accesscontrolrules._
+import com.dwolla.cloudflare.domain.model._
 
 private[cloudflare] object Implicits {
   implicit def toModel(dto: AccessControlRuleDTO): Rule = {
     Rule(
-      id = dto.id,
+      id = tagAccessControlRuleId(dto.id),
       notes = dto.notes,
       allowedModes = dto.allowed_modes,
       mode = dto.mode,

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/accounts/Account.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/accounts/Account.scala
@@ -1,7 +1,8 @@
 package com.dwolla.cloudflare.domain.model.accounts
 
-case class Account (
-  id: String,
-  name: String,
-  settings: AccountSettings
-)
+import com.dwolla.cloudflare.domain.model.AccountId
+
+case class Account(id: AccountId,
+                   name: String,
+                   settings: AccountSettings
+                  )

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/accounts/AccountMember.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/accounts/AccountMember.scala
@@ -1,14 +1,14 @@
 package com.dwolla.cloudflare.domain.model.accounts
 
 import com.dwolla.cloudflare.BaseUrl
+import com.dwolla.cloudflare.domain.model._
 import org.http4s.Uri
 
-case class AccountMember (
-  id: String,
-  user: User,
-  status: String,
-  roles: Seq[AccountRole]
-) {
-  def uri(accountId: String): Uri =
+case class AccountMember(id: AccountMemberId,
+                         user: User,
+                         status: String,
+                         roles: Seq[AccountRole]
+                        ) {
+  def uri(accountId: AccountId): Uri =
     BaseUrl / "accounts" / accountId / "members" / id
 }

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/accounts/Implicits.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/accounts/Implicits.scala
@@ -1,11 +1,14 @@
-package com.dwolla.cloudflare.domain.model.accounts
+package com.dwolla.cloudflare
+package domain
+package model
+package accounts
 
 import com.dwolla.cloudflare.domain.dto.accounts._
 
 object Implicits {
   implicit def toModel(dto: AccountDTO): Account = {
     Account(
-      id = dto.id,
+      id = tagAccountId(dto.id),
       name = dto.name,
       settings = toModel(dto.settings)
     )
@@ -19,7 +22,7 @@ object Implicits {
 
   implicit def toModel(dto: AccountMemberDTO): AccountMember = {
     AccountMember(
-      id = dto.id,
+      id = tagAccountMemberId(dto.id),
       user = dto.user,
       status = dto.status,
       roles = dto.roles.map(toModel)
@@ -28,7 +31,7 @@ object Implicits {
 
   implicit def toModel(dto: UserDTO): User = {
     User(
-      id = dto.id,
+      id = tagUserId(dto.id),
       firstName = dto.first_name,
       lastName = dto.last_name,
       emailAddress = dto.email,

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/accounts/User.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/accounts/User.scala
@@ -1,9 +1,10 @@
 package com.dwolla.cloudflare.domain.model.accounts
 
-case class User (
-  id: String,
-  firstName: Option[String],
-  lastName: Option[String],
-  emailAddress: String,
-  twoFactorEnabled: Boolean
-)
+import com.dwolla.cloudflare.domain.model._
+
+case class User(id: UserId,
+                firstName: Option[String],
+                lastName: Option[String],
+                emailAddress: String,
+                twoFactorEnabled: Boolean
+               )

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/package.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/package.scala
@@ -5,17 +5,32 @@ import shapeless.tag._
 package object model {
 
   type ZoneId = String @@ ZoneIdTag
+  type ResourceId = String @@ ResourceIdTag
   type RateLimitId = String @@ RateLimitIdTag
   type AccountId = String @@ AccountIdTag
+  type AccountMemberId = String @@ AccountMemberIdTag
+  type UserId = String @@ UserIdTag
+  type AccessControlRuleId = String @@ AccessControlRuleIdTag
+  type PhysicalResourceId = String @@ PhysicalResourceIdTag
 
   private[cloudflare] val tagZoneId: String ⇒ ZoneId = shapeless.tag[ZoneIdTag][String]
+  private[cloudflare] val tagResourceId: String ⇒ ResourceId = shapeless.tag[ResourceIdTag][String]
   private[cloudflare] val tagRateLimitId: String ⇒ RateLimitId = shapeless.tag[RateLimitIdTag][String]
   private[cloudflare] val tagAccountId: String ⇒ AccountId = shapeless.tag[AccountIdTag][String]
+  private[cloudflare] val tagAccountMemberId: String ⇒ AccountMemberId = shapeless.tag[AccountMemberIdTag][String]
+  private[cloudflare] val tagUserId: String ⇒ UserId = shapeless.tag[UserIdTag][String]
+  private[cloudflare] val tagAccessControlRuleId: String ⇒ AccessControlRuleId = shapeless.tag[AccessControlRuleIdTag][String]
+  private[cloudflare] val tagPhysicalResourceId: String ⇒ PhysicalResourceId = shapeless.tag[PhysicalResourceIdTag][String]
 
 }
 
 package model {
   trait ZoneIdTag
+  trait ResourceIdTag
   trait RateLimitIdTag
   trait AccountIdTag
+  trait AccountMemberIdTag
+  trait UserIdTag
+  trait AccessControlRuleIdTag
+  trait PhysicalResourceIdTag
 }

--- a/client/src/main/scala/com/dwolla/cloudflare/domain/model/response/Implicits.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/domain/model/response/Implicits.scala
@@ -10,7 +10,7 @@ object Implicits {
 
   implicit def toError(dto: ResponseInfoDTO): Error = {
     Error(
-      code = Option(dto.code),
+      code = dto.code,
       message = dto.message
     )
   }

--- a/client/src/main/scala/com/dwolla/cloudflare/package.scala
+++ b/client/src/main/scala/com/dwolla/cloudflare/package.scala
@@ -1,7 +1,17 @@
 package com.dwolla
 
+import com.dwolla.cloudflare.domain.model.Exceptions.UnexpectedCloudflareErrorException
+import cats.implicits._
+import fs2.Stream
 import org.http4s.Uri
 
 package object cloudflare {
   val BaseUrl: Uri = Uri.uri("https://api.cloudflare.com") / "client" / "v4"
+
+  implicit class IgnoringCloudflareErrorCodes[F[_], T](stream: Stream[F, T]) {
+    def returningEmptyOnErrorCodes(codes: Int*): Stream[F, T] = stream.recoverWith {
+      case ex: UnexpectedCloudflareErrorException if ex.errors.flatMap(_.code.toSeq).exists(codes.contains) ⇒ Stream.empty
+    }
+  }
+
 }

--- a/client/src/test/scala/com/dwolla/cloudflare/StreamingCloudflareApiExecutorSpec.scala
+++ b/client/src/test/scala/com/dwolla/cloudflare/StreamingCloudflareApiExecutorSpec.scala
@@ -70,9 +70,9 @@ class StreamingCloudflareApiExecutorSpec(implicit ee: ExecutionEnv) extends Spec
         None,
         success = false,
         errors = Some(List(
-          ResponseInfoDTO(6003, "Invalid request headers", Option(List(
-            ResponseInfoDTO(6102, "Invalid format for X-Auth-Email header"),
-            ResponseInfoDTO(6103, "Invalid format for X-Auth-Key header"),
+          ResponseInfoDTO(Option(6003), "Invalid request headers", Option(List(
+            ResponseInfoDTO(Option(6102), "Invalid format for X-Auth-Email header"),
+            ResponseInfoDTO(Option(6103), "Invalid format for X-Auth-Key header"),
           )))
         )),
         messages = None).asJson)
@@ -121,8 +121,8 @@ class StreamingCloudflareApiExecutorSpec(implicit ee: ExecutionEnv) extends Spec
 
       output.compile.toList.unsafeToFuture() should throwAn[AccessDenied].like {
         case ex@AccessDenied(msg) ⇒
-          msg should contain(ResponseInfoDTO(6102, "Invalid format for X-Auth-Email header"))
-          msg should contain(ResponseInfoDTO(6103, "Invalid format for X-Auth-Key header"))
+          msg should contain(ResponseInfoDTO(Option(6102), "Invalid format for X-Auth-Email header"))
+          msg should contain(ResponseInfoDTO(Option(6103), "Invalid format for X-Auth-Key header"))
           ex.getMessage must startWith(
             """The given credentials were invalid
               |

--- a/client/src/test/scala/dwolla/cloudflare/AccountMembersClientSpec.scala
+++ b/client/src/test/scala/dwolla/cloudflare/AccountMembersClientSpec.scala
@@ -1,0 +1,526 @@
+package dwolla.cloudflare
+
+import cats.effect._
+import com.dwolla.cloudflare._
+import com.dwolla.cloudflare.domain.model.Exceptions.UnexpectedCloudflareErrorException
+import com.dwolla.cloudflare.domain.model._
+import com.dwolla.cloudflare.domain.model.accounts._
+import org.http4s._
+import org.http4s.client.Client
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import shapeless.tag.@@
+import io.circe.literal._
+
+import scala.language.higherKinds
+
+class AccountMembersClientSpec(implicit ee: ExecutionEnv) extends Specification {
+  def tagString[T](s: String): String @@ T = shapeless.tag[T][String](s)
+
+  trait Setup extends Scope {
+    val authorization = CloudflareAuthorization("email", "key")
+    val fakeService = new FakeCloudflareService(authorization)
+
+    val fakeAccountId1 = tagString[AccountIdTag]("fake-account-id1")
+    val fakeAccountId2 = tagString[AccountIdTag]("fake-account-id2")
+    val fakeAccountId3 = tagString[AccountIdTag]("fake-account-id3")
+  }
+
+  "getMember" should {
+    "get account member by id and account id" in new Setup {
+      val accountId = fakeAccountId1
+      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
+
+      val http4sClient = fakeService.client(fakeService.getAccountMember(SampleResponses.Successes.accountMember, accountId, accountMemberId))
+      val client = buildAccountMembersClient(http4sClient, authorization)
+
+      private val output = client.getByUri(s"https://api.cloudflare.com/client/v4/accounts/$accountId/members/$accountMemberId")
+
+      output.compile.last.unsafeToFuture() must beSome(
+        AccountMember(
+          id = accountMemberId,
+          user = User(
+            id = tagString[UserIdTag]("fake-user-id"),
+            firstName = None,
+            lastName = None,
+            emailAddress = "myemail@test.com",
+            twoFactorEnabled = false
+          ),
+          status = "pending",
+          roles = List(
+            AccountRole(
+              id = "1111",
+              name = "Fake Role 1",
+              description = "this is the first fake role",
+              permissions = Map[String, AccountRolePermissions]("analytics" → AccountRolePermissions(read = true, edit = false))
+            ),
+            AccountRole(
+              id = "2222",
+              name = "Fake Role 2",
+              description = "second fake role",
+              permissions = Map[String, AccountRolePermissions](
+                "zone" → AccountRolePermissions(read = true, edit = false),
+                "logs" → AccountRolePermissions(read = true, edit = false)
+              )
+            )
+          )
+        )
+      ).await
+    }
+
+    "return None if not found" in new Setup {
+      val accountId = fakeAccountId1
+      val accountMemberId = tagString[AccountMemberIdTag]("missing-account-member-id")
+
+      val failure = SampleResponses.Failures.accountMemberDoesNotExist
+      val http4sClient = fakeService.client(fakeService.getAccountMember(failure.json, accountId, accountMemberId, failure.status))
+      val client = buildAccountMembersClient(http4sClient, authorization)
+
+      private val output = client.getById(accountId, accountMemberId)
+
+      output.compile.last.unsafeToFuture() must beNone.await
+    }
+  }
+
+  "addMember" should {
+    "add new member" in new Setup {
+      val accountId = fakeAccountId1
+      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
+      val email = "myemail@test.com"
+      val roleIds = List("1111", "2222")
+
+      val http4sClient = fakeService.client(fakeService.addAccountMember(SampleResponses.Successes.accountMember, accountId))
+      val client = buildAccountMembersClient(http4sClient, authorization)
+
+      private val output = client.addMember(accountId, email, roleIds)
+
+      output.compile.toList.unsafeToFuture() must contain(
+        AccountMember(
+          id = accountMemberId,
+          user = User(
+            id = tagString[UserIdTag]("fake-user-id"),
+            firstName = None,
+            lastName = None,
+            emailAddress = email,
+            twoFactorEnabled = false
+          ),
+          status = "pending",
+          roles = List(
+            AccountRole(
+              id = "1111",
+              name = "Fake Role 1",
+              description = "this is the first fake role",
+              permissions = Map[String, AccountRolePermissions]("analytics" → AccountRolePermissions(read = true, edit = false))
+            ),
+            AccountRole(
+              id = "2222",
+              name = "Fake Role 2",
+              description = "second fake role",
+              permissions = Map[String, AccountRolePermissions](
+                "zone" → AccountRolePermissions(read = true, edit = false),
+                "logs" → AccountRolePermissions(read = true, edit = false)
+              )
+            )
+          )
+        )
+      ).await
+    }
+
+    "throw unexpected exception if error adding new member" in new Setup {
+      val accountId = fakeAccountId1
+      val email = "me@abc123test.com"
+      val roleIds = List("1111", "2222")
+
+      val failure = SampleResponses.Failures.accountMemberCreationError
+      val http4sClient = fakeService.client(fakeService.addAccountMember(failure.json, accountId, failure.status))
+      val client = buildAccountMembersClient(http4sClient, authorization)
+
+      private val output = client.addMember(accountId, email, roleIds)
+
+      output.compile.last.attempt.unsafeToFuture() must beLeft[Throwable].like {
+        case ex: UnexpectedCloudflareErrorException ⇒ ex.getMessage must_==
+          """An unexpected Cloudflare error occurred. Errors:
+            |
+            | - Error(Some(1001),Invalid request: Value required for parameter 'email'.)
+            |     """.stripMargin
+      }.await
+    }
+  }
+
+  "updateMember" should {
+    "update existing member" in new Setup {
+      val email = "myemail@test.com"
+      val accountId = fakeAccountId1
+      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
+
+      val updatedAccountMember = AccountMember(
+        id = accountMemberId,
+        user = User(
+          id = tagString[UserIdTag]("fake-user-id"),
+          firstName = Some("Joe"),
+          lastName = Some("Smith"),
+          emailAddress = email,
+          twoFactorEnabled = false
+        ),
+        status = "pending",
+        roles = List(
+          AccountRole(
+            id = "1111",
+            name = "Fake Role 1",
+            description = "this is the first fake role",
+            permissions = Map[String, AccountRolePermissions]("analytics" → AccountRolePermissions(read = true, edit = false))
+          ),
+          AccountRole(
+            id = "2222",
+            name = "Fake Role 2",
+            description = "second fake role",
+            permissions = Map[String, AccountRolePermissions](
+              "zone" → AccountRolePermissions(read = true, edit = false),
+              "logs" → AccountRolePermissions(read = true, edit = false)
+            )
+          ),
+          AccountRole(
+            id = "3333",
+            name = "Fake Role 3",
+            description = "third fake role",
+            permissions = Map[String, AccountRolePermissions](
+              "crypto" → AccountRolePermissions(read = true, edit = false)
+            )
+          )
+        )
+      )
+
+      val http4sClient = fakeService.client(fakeService.updateAccountMember(SampleResponses.Successes.updatedAccountMember, accountId, updatedAccountMember.id))
+      val client = buildAccountMembersClient(http4sClient, authorization)
+
+      private val output = client.updateMember(accountId, updatedAccountMember)
+
+      output.compile.toList.unsafeToFuture() must contain(updatedAccountMember).await
+    }
+
+    "throw unexpected exception if error updating existing member" in new Setup {
+      val accountId = fakeAccountId1
+      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
+
+      val updatedAccountMember = AccountMember(
+        id = accountMemberId,
+        user = User(
+          id = tagString[UserIdTag]("fake-user-id"),
+          firstName = Some("Joe"),
+          lastName = Some("Smith"),
+          emailAddress = "myemail@test.com",
+          twoFactorEnabled = false
+        ),
+        status = "pending",
+        roles = List(
+          AccountRole(
+            id = "1111",
+            name = "Fake Role 1",
+            description = "this is the first fake role",
+            permissions = Map[String, AccountRolePermissions]("analytics" → AccountRolePermissions(read = true, edit = false))
+          ),
+          AccountRole(
+            id = "2222",
+            name = "Fake Role 2",
+            description = "second fake role",
+            permissions = Map[String, AccountRolePermissions](
+              "zone" → AccountRolePermissions(read = true, edit = false),
+              "logs" → AccountRolePermissions(read = true, edit = false)
+            )
+          ),
+          AccountRole(
+            id = "3333",
+            name = "Fake Role 3",
+            description = "third fake role",
+            permissions = Map[String, AccountRolePermissions](
+              "crypto" → AccountRolePermissions(read = true, edit = false)
+            )
+          )
+        )
+      )
+
+      val failure = SampleResponses.Failures.accountMemberUpdateError
+      val http4sClient = fakeService.client(fakeService.updateAccountMember(failure.json, accountId, updatedAccountMember.id, failure.status))
+      val client = buildAccountMembersClient(http4sClient, authorization)
+
+      private val output = client.updateMember(accountId, updatedAccountMember)
+
+      output.compile.last.attempt.unsafeToFuture() must beLeft[Throwable].like {
+        case ex: UnexpectedCloudflareErrorException ⇒ ex.getMessage must_==
+          """An unexpected Cloudflare error occurred. Errors:
+            |
+            | - Error(Some(1001),Invalid request: Invalid roles)
+            |     """.stripMargin
+      }.await
+    }
+  }
+
+  "removeMember" should {
+    "remove member from account" in new Setup {
+      val accountId = fakeAccountId1
+      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
+
+      val http4sClient = fakeService.client(fakeService.removeAccountMember(SampleResponses.Successes.removedAccountMember, accountId, accountMemberId))
+      val client = buildAccountMembersClient(http4sClient, authorization)
+
+      private val output = client.removeMember(accountId, accountMemberId)
+
+      output.compile.last.unsafeToFuture() must beSome(accountMemberId).await
+    }
+
+    "throw unexpected exception if error removing member" in new Setup {
+      val accountId = fakeAccountId1
+      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
+
+      val failure = SampleResponses.Failures.accountMemberRemovalError
+      val http4sClient = fakeService.client(fakeService.removeAccountMember(failure.json, accountId, accountMemberId, failure.status))
+      val client = buildAccountMembersClient(http4sClient, authorization)
+
+      private val output = client.removeMember(accountId, accountMemberId)
+
+      output.compile.last.attempt.unsafeToFuture() must beLeft[Throwable].like {
+        case ex: UnexpectedCloudflareErrorException ⇒ ex.getMessage must_==
+          """An unexpected Cloudflare error occurred. Errors:
+            |
+            | - Error(Some(7003),Could not route to /accounts/fake-account-id1/members/fake-account-member-id, perhaps your object identifier is invalid?)
+            | - Error(Some(7000),No route for that URI)
+            |     """.stripMargin
+      }.await
+    }
+
+    "throw not found exception if member not in account" in new Setup {
+      val accountId = fakeAccountId1
+      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
+
+      val failure = SampleResponses.Failures.accountDoesNotExist
+      val http4sClient = fakeService.client(fakeService.removeAccountMember(failure.json, accountId, accountMemberId, failure.status))
+      val client = buildAccountMembersClient(http4sClient, authorization)
+
+      private val output = client.removeMember(accountId, accountMemberId)
+
+      output.compile.last.attempt.unsafeToFuture() must beLeft[Throwable].like {
+        case ex: AccountMemberDoesNotExistException ⇒ ex.getMessage must_==
+          "The account member fake-account-member-id not found for account fake-account-id1."
+      }.await
+    }
+  }
+
+  private def buildAccountMembersClient[F[_]: Sync](http4sClient: Client[F], authorization: CloudflareAuthorization): AccountMembersClient[F] =
+    AccountMembersClient(new StreamingCloudflareApiExecutor(http4sClient, authorization))
+
+  private object SampleResponses {
+    object Successes {
+      val accountMember =
+    json"""{
+             "success": true,
+             "errors": [],
+             "messages": [],
+             "result": {
+               "id": "fake-account-member-id",
+               "user":
+               {
+                 "id": "fake-user-id",
+                 "first_name": null,
+                 "last_name": null,
+                 "email": "myemail@test.com",
+                 "two_factor_authentication_enabled": false
+               },
+               "status": "pending",
+               "roles": [
+                 {
+                   "id": "1111",
+                   "name": "Fake Role 1",
+                   "description": "this is the first fake role",
+                   "permissions":
+                   {
+                     "analytics":
+                     {
+                       "read": true,
+                       "edit": false
+                     }
+                   }
+                 },
+                 {
+                   "id": "2222",
+                   "name": "Fake Role 2",
+                   "description": "second fake role",
+                   "permissions":
+                   {
+                     "zone":
+                     {
+                       "read": true,
+                       "edit": false
+                     },
+                     "logs":
+                     {
+                       "read": true,
+                       "edit": false
+                     }
+                   }
+                 }
+               ]
+             }
+           }
+        """.noSpaces
+
+      val updatedAccountMember =
+    json"""{
+             "success": true,
+             "errors": [],
+             "messages": [],
+             "result": {
+               "id": "fake-account-member-id",
+               "user":
+               {
+                 "id": "fake-user-id",
+                 "first_name": "Joe",
+                 "last_name": "Smith",
+                 "email": "myemail@test.com",
+                 "two_factor_authentication_enabled": false
+               },
+               "status": "pending",
+               "roles": [
+                 {
+                   "id": "1111",
+                   "name": "Fake Role 1",
+                   "description": "this is the first fake role",
+                   "permissions":
+                   {
+                     "analytics":
+                     {
+                       "read": true,
+                       "edit": false
+                     }
+                   }
+                 },
+                 {
+                   "id": "2222",
+                   "name": "Fake Role 2",
+                   "description": "second fake role",
+                   "permissions":
+                   {
+                     "zone":
+                     {
+                       "read": true,
+                       "edit": false
+                     },
+                     "logs":
+                     {
+                       "read": true,
+                       "edit": false
+                     }
+                   }
+                 },
+                 {
+                   "id": "3333",
+                   "name": "Fake Role 3",
+                   "description": "third fake role",
+                   "permissions":
+                   {
+                     "crypto":
+                     {
+                       "read": true,
+                       "edit": false
+                     }
+                   }
+                 }
+               ]
+             }
+           }
+        """.noSpaces
+
+      val removedAccountMember =
+    json"""
+           {
+             "result": {
+               "id": "fake-account-member-id"
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
+    }
+
+    object Failures {
+      case class Failure(status: Status, json: String)
+
+      val accountMemberRemovalError = Failure(Status.BadRequest,
+    json"""{
+             "success": false,
+             "errors": [
+               {
+                 "code": 7003,
+                 "message": "Could not route to /accounts/fake-account-id1/members/fake-account-member-id, perhaps your object identifier is invalid?"
+               },
+               {
+                 "code": 7000,
+                 "message": "No route for that URI"
+               }
+             ],
+             "messages": [],
+             "result": null
+           }
+        """.noSpaces)
+
+      val accountMemberUpdateError = Failure(Status.BadRequest,
+    json"""{
+             "success": false,
+             "errors": [
+               {
+                 "code": 1001,
+                 "message": "Invalid request: Invalid roles"
+               }
+             ],
+             "messages": [],
+             "result": null
+           }
+        """.noSpaces)
+
+      val accountMemberCreationError = Failure(Status.BadRequest,
+    json"""{
+             "success": false,
+             "errors": [
+               {
+                 "code": 1001,
+                 "message": "Invalid request: Value required for parameter 'email'."
+               }
+             ],
+             "messages": [],
+             "result": null
+           }
+        """.noSpaces)
+
+      val accountMemberDoesNotExist = Failure(Status.NotFound,
+    json"""
+           {
+             "success": false,
+             "errors": [
+               {
+                 "code": 1003,
+                 "message": "Member not found for account"
+                }
+             ],
+             "messages": [],
+             "result": null
+           }
+        """.noSpaces)
+
+      val accountDoesNotExist = Failure(Status.NotFound,
+    json"""{
+             "success": false,
+             "errors": [
+               {
+                 "code": 1003,
+                 "message": "Account not found"
+               }
+             ],
+             "messages": [],
+             "result": null
+           }
+        """.noSpaces)
+    }
+  }
+
+}

--- a/client/src/test/scala/dwolla/cloudflare/AccountsClientSpec.scala
+++ b/client/src/test/scala/dwolla/cloudflare/AccountsClientSpec.scala
@@ -2,18 +2,19 @@ package dwolla.cloudflare
 
 import cats.effect._
 import com.dwolla.cloudflare._
-import com.dwolla.cloudflare.domain.model.Exceptions.UnexpectedCloudflareErrorException
 import com.dwolla.cloudflare.domain.model._
 import com.dwolla.cloudflare.domain.model.accounts._
-import org.http4s.Status
+import org.http4s.{HttpService, Status}
 import org.http4s.client.Client
+import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import shapeless.tag.@@
+import io.circe.literal._
 
 import scala.language.higherKinds
 
-class AccountsClientSpec extends Specification {
+class AccountsClientSpec(implicit ee: ExecutionEnv) extends Specification {
   def tagString[T](s: String): String @@ T = shapeless.tag[T][String](s)
 
   trait Setup extends Scope {
@@ -69,9 +70,36 @@ class AccountsClientSpec extends Specification {
     }
   }
 
+  "getByUri" should {
+    "get account by uri" in new Setup {
+      val http4sClient = fakeService.client(fakeService.accountById(SampleResponses.Successes.getAccount, fakeAccountId1))
+      val client = buildAccountsClient(http4sClient, authorization)
+
+      private val output = client.getByUri(s"https://api.cloudflare.com/client/v4/accounts/$fakeAccountId1")
+
+      output.compile.last.unsafeToFuture() must beSome(
+        Account(
+          id = fakeAccountId1,
+          name = "Fake Account Org",
+          settings = AccountSettings(enforceTwoFactor = false)
+        )
+      ).await
+    }
+
+    "return None for invalid URIs" in new Setup {
+      val client = buildAccountsClient(fakeService.client(HttpService.empty[IO]), authorization)
+
+      private val output = client.getByUri("https://hydragents.xyz")
+
+      output.compile.toList.unsafeToFuture() must beEmpty[List[Account]].await
+      client.parseUri("https://hydragents.xyz") must beNone
+    }
+
+  }
+
   "getById" should {
     "get account by id" in new Setup {
-      val accountId = fakeAccountId1
+      val accountId: String = fakeAccountId1
 
       val http4sClient = fakeService.client(fakeService.accountById(SampleResponses.Successes.getAccount, accountId))
       val client = buildAccountsClient(http4sClient, authorization)
@@ -81,7 +109,7 @@ class AccountsClientSpec extends Specification {
 
       output must beSome(
         Account(
-          id = accountId,
+          id = fakeAccountId1,
           name = "Fake Account Org",
           settings = AccountSettings(enforceTwoFactor = false)
         )
@@ -208,307 +236,6 @@ class AccountsClientSpec extends Specification {
     }
   }
 
-  "getMember" should {
-    "get account member by id and account id" in new Setup {
-      val accountId = fakeAccountId1
-      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
-
-      val http4sClient = fakeService.client(fakeService.getAccountMember(SampleResponses.Successes.accountMember, accountId, accountMemberId))
-      val client = buildAccountsClient(http4sClient, authorization)
-
-      val output: Option[AccountMember] = client.getMember(accountId, accountMemberId)
-        .compile.toList.map(_.headOption).unsafeRunSync()
-
-      output must beSome(
-        AccountMember(
-          id = accountMemberId,
-          user = User(
-            id = tagString[UserIdTag]("fake-user-id"),
-            firstName = None,
-            lastName = None,
-            emailAddress = "myemail@test.com",
-            twoFactorEnabled = false
-          ),
-          status = "pending",
-          roles = List(
-            AccountRole(
-              id = "1111",
-              name = "Fake Role 1",
-              description = "this is the first fake role",
-              permissions = Map[String, AccountRolePermissions]("analytics" → AccountRolePermissions(read = true, edit = false))
-            ),
-            AccountRole(
-              id = "2222",
-              name = "Fake Role 2",
-              description = "second fake role",
-              permissions = Map[String, AccountRolePermissions](
-                "zone" → AccountRolePermissions(read = true, edit = false),
-                "logs" → AccountRolePermissions(read = true, edit = false)
-              )
-            )
-          )
-        )
-      )
-    }
-
-    "return None if not found" in new Setup {
-      val accountId = fakeAccountId1
-      val accountMemberId = tagString[AccountMemberIdTag]("missing-account-member-id")
-
-      val failure = SampleResponses.Failures.accountMemberDoesNotExist
-      val http4sClient = fakeService.client(fakeService.getAccountMember(failure.json, accountId, accountMemberId, failure.status))
-      val client = buildAccountsClient(http4sClient, authorization)
-
-      val output: Option[AccountMember] = client.getMember(accountId, accountMemberId)
-        .compile.toList.map(_.headOption).unsafeRunSync()
-
-      output must beNone
-    }
-  }
-
-  "addMember" should {
-    "add new member" in new Setup {
-      val accountId = fakeAccountId1
-      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
-      val email = "myemail@test.com"
-      val roleIds = List("1111", "2222")
-
-      val http4sClient = fakeService.client(fakeService.addAccountMember(SampleResponses.Successes.accountMember, accountId))
-      val client = buildAccountsClient(http4sClient, authorization)
-
-      val output = client.addMember(accountId, email, roleIds)
-        .compile.toList.unsafeRunSync()
-
-      output must be_==(
-        List(AccountMember(
-            id = accountMemberId,
-            user = User(
-              id = tagString[UserIdTag]("fake-user-id"),
-              firstName = None,
-              lastName = None,
-              emailAddress = email,
-              twoFactorEnabled = false
-            ),
-            status = "pending",
-            roles = List(
-              AccountRole(
-                id = "1111",
-                name = "Fake Role 1",
-                description = "this is the first fake role",
-                permissions = Map[String, AccountRolePermissions]("analytics" → AccountRolePermissions(read = true, edit = false))
-              ),
-              AccountRole(
-                id = "2222",
-                name = "Fake Role 2",
-                description = "second fake role",
-                permissions = Map[String, AccountRolePermissions](
-                  "zone" → AccountRolePermissions(read = true, edit = false),
-                  "logs" → AccountRolePermissions(read = true, edit = false)
-                )
-              )
-            )
-          )
-        )
-      )
-    }
-
-    "throw unexpected exception if error adding new member" in new Setup {
-      val accountId = fakeAccountId1
-      val email = "me@abc123test.com"
-      val roleIds = List("1111", "2222")
-
-      val failure = SampleResponses.Failures.accountMemberCreationError
-      val http4sClient = fakeService.client(fakeService.addAccountMember(failure.json, accountId, failure.status))
-      val client = buildAccountsClient(http4sClient, authorization)
-
-      val output = client.addMember(accountId, email, roleIds)
-        .compile
-        .toList
-        .attempt
-        .unsafeRunSync()
-
-      output must beLeft[Throwable].like {
-        case ex: UnexpectedCloudflareErrorException ⇒ ex.getMessage must_==
-          """An unexpected Cloudflare error occurred. Errors:
-            |
-            | - Error(Some(1001),Invalid request: Value required for parameter 'email'.)
-            |     """.stripMargin
-      }
-    }
-  }
-
-  "updateMember" should {
-    "update existing member" in new Setup {
-      val email = "myemail@test.com"
-      val accountId = fakeAccountId1
-      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
-
-      val updatedAccountMember = AccountMember(
-        id = accountMemberId,
-        user = User(
-          id = tagString[UserIdTag]("fake-user-id"),
-          firstName = Some("Joe"),
-          lastName = Some("Smith"),
-          emailAddress = email,
-          twoFactorEnabled = false
-        ),
-        status = "pending",
-        roles = List(
-          AccountRole(
-            id = "1111",
-            name = "Fake Role 1",
-            description = "this is the first fake role",
-            permissions = Map[String, AccountRolePermissions]("analytics" → AccountRolePermissions(read = true, edit = false))
-          ),
-          AccountRole(
-            id = "2222",
-            name = "Fake Role 2",
-            description = "second fake role",
-            permissions = Map[String, AccountRolePermissions](
-              "zone" → AccountRolePermissions(read = true, edit = false),
-              "logs" → AccountRolePermissions(read = true, edit = false)
-            )
-          ),
-          AccountRole(
-            id = "3333",
-            name = "Fake Role 3",
-            description = "third fake role",
-            permissions = Map[String, AccountRolePermissions](
-              "crypto" → AccountRolePermissions(read = true, edit = false)
-            )
-          )
-        )
-      )
-
-      val http4sClient = fakeService.client(fakeService.updateAccountMember(SampleResponses.Successes.updatedAccountMember, accountId, updatedAccountMember.id))
-      val client = buildAccountsClient(http4sClient, authorization)
-
-      val output = client.updateMember(accountId, updatedAccountMember)
-        .compile.toList.unsafeRunSync()
-
-      output must be_==(List(updatedAccountMember))
-    }
-
-    "throw unexpected exception if error updating existing member" in new Setup {
-      val accountId = fakeAccountId1
-      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
-
-      val updatedAccountMember = AccountMember(
-        id = accountMemberId,
-        user = User(
-          id = tagString[UserIdTag]("fake-user-id"),
-          firstName = Some("Joe"),
-          lastName = Some("Smith"),
-          emailAddress = "myemail@test.com",
-          twoFactorEnabled = false
-        ),
-        status = "pending",
-        roles = List(
-          AccountRole(
-            id = "1111",
-            name = "Fake Role 1",
-            description = "this is the first fake role",
-            permissions = Map[String, AccountRolePermissions]("analytics" → AccountRolePermissions(read = true, edit = false))
-          ),
-          AccountRole(
-            id = "2222",
-            name = "Fake Role 2",
-            description = "second fake role",
-            permissions = Map[String, AccountRolePermissions](
-              "zone" → AccountRolePermissions(read = true, edit = false),
-              "logs" → AccountRolePermissions(read = true, edit = false)
-            )
-          ),
-          AccountRole(
-            id = "3333",
-            name = "Fake Role 3",
-            description = "third fake role",
-            permissions = Map[String, AccountRolePermissions](
-              "crypto" → AccountRolePermissions(read = true, edit = false)
-            )
-          )
-        )
-      )
-
-      val failure = SampleResponses.Failures.accountMemberUpdateError
-      val http4sClient = fakeService.client(fakeService.updateAccountMember(failure.json, accountId, updatedAccountMember.id, failure.status))
-      val client = buildAccountsClient(http4sClient, authorization)
-
-      val output = client.updateMember(accountId, updatedAccountMember)
-        .compile
-        .toList
-        .attempt
-        .unsafeRunSync()
-
-      output must beLeft[Throwable].like {
-        case ex: UnexpectedCloudflareErrorException ⇒ ex.getMessage must_==
-          """An unexpected Cloudflare error occurred. Errors:
-            |
-            | - Error(Some(1001),Invalid request: Invalid roles)
-            |     """.stripMargin
-      }
-    }
-  }
-
-  "removeMember" should {
-    "remove member from account" in new Setup {
-      val accountId = fakeAccountId1
-      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
-
-      val http4sClient = fakeService.client(fakeService.removeAccountMember(SampleResponses.Successes.removedAccountMember, accountId, accountMemberId))
-      val client = buildAccountsClient(http4sClient, authorization)
-
-      val output = client.removeMember(accountId, accountMemberId)
-        .compile.toList.unsafeRunSync()
-
-      output must be_==(List(accountMemberId))
-    }
-
-    "throw unexpected exception if error removing member" in new Setup {
-      val accountId = fakeAccountId1
-      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
-
-      val failure = SampleResponses.Failures.accountMemberRemovalError
-      val http4sClient = fakeService.client(fakeService.removeAccountMember(failure.json, accountId, accountMemberId, failure.status))
-      val client = buildAccountsClient(http4sClient, authorization)
-
-      val output = client.removeMember(accountId, accountMemberId)
-        .compile
-        .toList
-        .attempt
-        .unsafeRunSync()
-
-      output must beLeft[Throwable].like {
-        case ex: UnexpectedCloudflareErrorException ⇒ ex.getMessage must_==
-          """An unexpected Cloudflare error occurred. Errors:
-            |
-            | - Error(Some(7003),Could not route to /accounts/fake-account-id1/members/fake-account-member-id, perhaps your object identifier is invalid?)
-            | - Error(Some(7000),No route for that URI)
-            |     """.stripMargin
-      }
-    }
-
-    "throw not found exception if member not in account" in new Setup {
-      val accountId = fakeAccountId1
-      val accountMemberId = tagString[AccountMemberIdTag]("fake-account-member-id")
-
-      val failure = SampleResponses.Failures.accountDoesNotExist
-      val http4sClient = fakeService.client(fakeService.removeAccountMember(failure.json, accountId, accountMemberId, failure.status))
-      val client = buildAccountsClient(http4sClient, authorization)
-
-      val output = client.removeMember(accountId, accountMemberId)
-        .compile
-        .toList
-        .attempt
-        .unsafeRunSync()
-
-      output must beLeft[Throwable].like {
-        case ex: AccountMemberDoesNotExistException ⇒ ex.getMessage must_==
-          "The account member fake-account-member-id not found for account fake-account-id1."
-      }
-    }
-  }
-
   def buildAccountsClient[F[_]: Sync](http4sClient: Client[F], authorization: CloudflareAuthorization): AccountsClient[F] = {
     val fakeHttp4sExecutor = new StreamingCloudflareApiExecutor(http4sClient, authorization)
     AccountsClient(fakeHttp4sExecutor)
@@ -517,489 +244,297 @@ class AccountsClientSpec extends Specification {
   private object SampleResponses {
     object Successes {
       val listAccounts =
-        """{
-          |  "result": [
-          |    {
-          |      "id": "fake-account-id1",
-          |      "name": "Fake Account Org",
-          |      "settings":
-          |      {
-          |        "enforce_twofactor": false
-          |      }
-          |    },
-          |    {
-          |      "id": "fake-account-id2",
-          |      "name": "Another Fake Account Biz",
-          |      "settings":
-          |      {
-          |        "enforce_twofactor": true
-          |      }
-          |    }
-          |  ],
-          |  "result_info": {
-          |    "page": 1,
-          |    "per_page": 20,
-          |    "total_pages": 1,
-          |    "count": 2,
-          |    "total_count": 2
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""{
+             "result": [
+               {
+                 "id": "fake-account-id1",
+                 "name": "Fake Account Org",
+                 "settings":
+                 {
+                   "enforce_twofactor": false
+                 }
+               },
+               {
+                 "id": "fake-account-id2",
+                 "name": "Another Fake Account Biz",
+                 "settings":
+                 {
+                   "enforce_twofactor": true
+                 }
+               }
+             ],
+             "result_info": {
+               "page": 1,
+               "per_page": 20,
+               "total_pages": 1,
+               "count": 2,
+               "total_count": 2
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
 
       val listAccountsPage1 =
-        """{
-          |  "result": [
-          |    {
-          |      "id": "fake-account-id1",
-          |      "name": "Fake Account Org",
-          |      "settings":
-          |      {
-          |        "enforce_twofactor": false
-          |      }
-          |    }
-          |  ],
-          |  "result_info": {
-          |    "page": 1,
-          |    "per_page": 1,
-          |    "total_pages": 3,
-          |    "count": 1,
-          |    "total_count": 3
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""{
+             "result": [
+               {
+                 "id": "fake-account-id1",
+                 "name": "Fake Account Org",
+                 "settings":
+                 {
+                   "enforce_twofactor": false
+                 }
+               }
+             ],
+             "result_info": {
+               "page": 1,
+               "per_page": 1,
+               "total_pages": 3,
+               "count": 1,
+               "total_count": 3
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
 
       val listAccountsPage2 =
-        """{
-          |  "result": [
-          |    {
-          |      "id": "fake-account-id2",
-          |      "name": "Fake Account Org 2",
-          |      "settings":
-          |      {
-          |        "enforce_twofactor": false
-          |      }
-          |    }
-          |  ],
-          |  "result_info": {
-          |    "page": 2,
-          |    "per_page": 1,
-          |    "total_pages": 3,
-          |    "count": 1,
-          |    "total_count": 3
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""{
+             "result": [
+               {
+                 "id": "fake-account-id2",
+                 "name": "Fake Account Org 2",
+                 "settings":
+                 {
+                   "enforce_twofactor": false
+                 }
+               }
+             ],
+             "result_info": {
+               "page": 2,
+               "per_page": 1,
+               "total_pages": 3,
+               "count": 1,
+               "total_count": 3
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
 
       val listAccountsPage3 =
-        """{
-          |  "result": [
-          |    {
-          |      "id": "fake-account-id3",
-          |      "name": "Fake Account Org 3",
-          |      "settings":
-          |      {
-          |        "enforce_twofactor": true
-          |      }
-          |    }
-          |  ],
-          |  "result_info": {
-          |    "page": 3,
-          |    "per_page": 1,
-          |    "total_pages": 3,
-          |    "count": 1,
-          |    "total_count": 3
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""{
+             "result": [
+               {
+                 "id": "fake-account-id3",
+                 "name": "Fake Account Org 3",
+                 "settings":
+                 {
+                   "enforce_twofactor": true
+                 }
+               }
+             ],
+             "result_info": {
+               "page": 3,
+               "per_page": 1,
+               "total_pages": 3,
+               "count": 1,
+               "total_count": 3
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
 
       val getAccount =
-        """{
-          |  "result": {
-          |    "id": "fake-account-id1",
-          |    "name": "Fake Account Org",
-          |    "settings": {
-          |      "enforce_twofactor": false
-          |    }
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""{
+             "result": {
+               "id": "fake-account-id1",
+               "name": "Fake Account Org",
+               "settings": {
+                 "enforce_twofactor": false
+               }
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
 
       val getRoles =
-        """
-          |{
-          |  "result": [
-          |    {
-          |      "id": "1111",
-          |      "name": "Fake Role 1",
-          |      "description": "this is the first fake role",
-          |      "permissions":
-          |      {
-          |        "analytics":
-          |        {
-          |          "read": true,
-          |          "edit": false
-          |        }
-          |      }
-          |    },
-          |    {
-          |      "id": "2222",
-          |      "name": "Fake Role 2",
-          |      "description": "second fake role",
-          |      "permissions":
-          |      {
-          |        "zone":
-          |        {
-          |          "read": true,
-          |          "edit": false
-          |        },
-          |        "logs":
-          |        {
-          |          "read": true,
-          |          "edit": false
-          |        }
-          |      }
-          |    }
-          |  ],
-          |  "result_info": {
-          |    "page": 1,
-          |    "per_page": 20,
-          |    "total_pages": 1,
-          |    "count": 2,
-          |    "total_count": 2
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""
+           {
+             "result": [
+               {
+                 "id": "1111",
+                 "name": "Fake Role 1",
+                 "description": "this is the first fake role",
+                 "permissions":
+                 {
+                   "analytics":
+                   {
+                     "read": true,
+                     "edit": false
+                   }
+                 }
+               },
+               {
+                 "id": "2222",
+                 "name": "Fake Role 2",
+                 "description": "second fake role",
+                 "permissions":
+                 {
+                   "zone":
+                   {
+                     "read": true,
+                     "edit": false
+                   },
+                   "logs":
+                   {
+                     "read": true,
+                     "edit": false
+                   }
+                 }
+               }
+             ],
+             "result_info": {
+               "page": 1,
+               "per_page": 20,
+               "total_pages": 1,
+               "count": 2,
+               "total_count": 2
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
 
       val getRolesPage1 =
-        """
-          |{
-          |  "result": [
-          |    {
-          |      "id": "1111",
-          |      "name": "Fake Role 1",
-          |      "description": "this is the first fake role",
-          |      "permissions":
-          |      {
-          |        "analytics":
-          |        {
-          |          "read": true,
-          |          "edit": false
-          |        }
-          |      }
-          |    }
-          |  ],
-          |  "result_info": {
-          |    "page": 1,
-          |    "per_page": 1,
-          |    "total_pages": 3,
-          |    "count": 1,
-          |    "total_count": 3
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""
+           {
+             "result": [
+               {
+                 "id": "1111",
+                 "name": "Fake Role 1",
+                 "description": "this is the first fake role",
+                 "permissions":
+                 {
+                   "analytics":
+                   {
+                     "read": true,
+                     "edit": false
+                   }
+                 }
+               }
+             ],
+             "result_info": {
+               "page": 1,
+               "per_page": 1,
+               "total_pages": 3,
+               "count": 1,
+               "total_count": 3
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
 
       val getRolesPage2 =
-        """
-          |{
-          |  "result": [
-          |    {
-          |      "id": "2222",
-          |      "name": "Fake Role 2",
-          |      "description": "second fake role",
-          |      "permissions":
-          |      {
-          |        "zone":
-          |        {
-          |          "read": true,
-          |          "edit": false
-          |        },
-          |        "logs":
-          |        {
-          |          "read": true,
-          |          "edit": false
-          |        }
-          |      }
-          |    }
-          |  ],
-          |  "result_info": {
-          |    "page": 2,
-          |    "per_page": 1,
-          |    "total_pages": 3,
-          |    "count": 1,
-          |    "total_count": 3
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""
+           {
+             "result": [
+               {
+                 "id": "2222",
+                 "name": "Fake Role 2",
+                 "description": "second fake role",
+                 "permissions":
+                 {
+                   "zone":
+                   {
+                     "read": true,
+                     "edit": false
+                   },
+                   "logs":
+                   {
+                     "read": true,
+                     "edit": false
+                   }
+                 }
+               }
+             ],
+             "result_info": {
+               "page": 2,
+               "per_page": 1,
+               "total_pages": 3,
+               "count": 1,
+               "total_count": 3
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
 
       val getRolesPage3 =
-        """
-          |{
-          |  "result": [
-          |    {
-          |      "id": "3333",
-          |      "name": "Fake Full Role 3",
-          |      "description": "full permissions",
-          |      "permissions":
-          |      {
-          |        "legal":
-          |        {
-          |          "read": true,
-          |          "edit": true
-          |        },
-          |        "billing":
-          |        {
-          |          "read": true,
-          |          "edit": true
-          |        }
-          |      }
-          |    }
-          |  ],
-          |  "result_info": {
-          |    "page": 3,
-          |    "per_page": 1,
-          |    "total_pages": 3,
-          |    "count": 1,
-          |    "total_count": 3
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
-
-      val accountMember =
-        """{
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": [],
-          |  "result": {
-          |    "id": "fake-account-member-id",
-          |    "user":
-          |    {
-          |      "id": "fake-user-id",
-          |      "first_name": null,
-          |      "last_name": null,
-          |      "email": "myemail@test.com",
-          |      "two_factor_authentication_enabled": false
-          |    },
-          |    "status": "pending",
-          |    "roles": [
-          |      {
-          |        "id": "1111",
-          |        "name": "Fake Role 1",
-          |        "description": "this is the first fake role",
-          |        "permissions":
-          |        {
-          |          "analytics":
-          |          {
-          |            "read": true,
-          |            "edit": false
-          |          }
-          |        }
-          |      },
-          |      {
-          |        "id": "2222",
-          |        "name": "Fake Role 2",
-          |        "description": "second fake role",
-          |        "permissions":
-          |        {
-          |          "zone":
-          |          {
-          |            "read": true,
-          |            "edit": false
-          |          },
-          |          "logs":
-          |          {
-          |            "read": true,
-          |            "edit": false
-          |          }
-          |        }
-          |      }
-          |    ]
-          |  }
-          |}
-        """.stripMargin
-
-      val updatedAccountMember =
-        """{
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": [],
-          |  "result": {
-          |    "id": "fake-account-member-id",
-          |    "user":
-          |    {
-          |      "id": "fake-user-id",
-          |      "first_name": "Joe",
-          |      "last_name": "Smith",
-          |      "email": "myemail@test.com",
-          |      "two_factor_authentication_enabled": false
-          |    },
-          |    "status": "pending",
-          |    "roles": [
-          |      {
-          |        "id": "1111",
-          |        "name": "Fake Role 1",
-          |        "description": "this is the first fake role",
-          |        "permissions":
-          |        {
-          |          "analytics":
-          |          {
-          |            "read": true,
-          |            "edit": false
-          |          }
-          |        }
-          |      },
-          |      {
-          |        "id": "2222",
-          |        "name": "Fake Role 2",
-          |        "description": "second fake role",
-          |        "permissions":
-          |        {
-          |          "zone":
-          |          {
-          |            "read": true,
-          |            "edit": false
-          |          },
-          |          "logs":
-          |          {
-          |            "read": true,
-          |            "edit": false
-          |          }
-          |        }
-          |      },
-          |      {
-          |        "id": "3333",
-          |        "name": "Fake Role 3",
-          |        "description": "third fake role",
-          |        "permissions":
-          |        {
-          |          "crypto":
-          |          {
-          |            "read": true,
-          |            "edit": false
-          |          }
-          |        }
-          |      }
-          |    ]
-          |  }
-          |}
-        """.stripMargin
-
-      val removedAccountMember =
-        """
-          |{
-          |  "result": {
-          |    "id": "fake-account-member-id"
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""
+           {
+             "result": [
+               {
+                 "id": "3333",
+                 "name": "Fake Full Role 3",
+                 "description": "full permissions",
+                 "permissions":
+                 {
+                   "legal":
+                   {
+                     "read": true,
+                     "edit": true
+                   },
+                   "billing":
+                   {
+                     "read": true,
+                     "edit": true
+                   }
+                 }
+               }
+             ],
+             "result_info": {
+               "page": 3,
+               "per_page": 1,
+               "total_pages": 3,
+               "count": 1,
+               "total_count": 3
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
     }
 
     object Failures {
       case class Failure(status: Status, json: String)
 
-      val accountMemberRemovalError = Failure(Status.BadRequest,
-        """{
-          |  "success": false,
-          |  "errors": [
-          |    {
-          |      "code": 7003,
-          |      "message": "Could not route to /accounts/fake-account-id1/members/fake-account-member-id, perhaps your object identifier is invalid?"
-          |    },
-          |    {
-          |      "code": 7000,
-          |      "message": "No route for that URI"
-          |    }
-          |  ],
-          |  "messages": [],
-          |  "result": null
-          |}
-        """.stripMargin)
-
-      val accountMemberUpdateError = Failure(Status.BadRequest,
-        """{
-          |  "success": false,
-          |  "errors": [
-          |    {
-          |      "code": 1001,
-          |      "message": "Invalid request: Invalid roles"
-          |    }
-          |  ],
-          |  "messages": [],
-          |  "result": null
-          |}
-        """.stripMargin)
-
-      val accountMemberCreationError = Failure(Status.BadRequest,
-        """{
-          |  "success": false,
-          |  "errors": [
-          |    {
-          |      "code": 1001,
-          |      "message": "Invalid request: Value required for parameter 'email'."
-          |    }
-          |  ],
-          |  "messages": [],
-          |  "result": null
-          |}
-        """.stripMargin)
-
-      val accountMemberDoesNotExist = Failure(Status.NotFound,
-        """
-          |{
-          |  "success": false,
-          |  "errors": [
-          |    {
-          |      "code": 1003,
-          |      "message": "Member not found for account"
-          |     }
-          |  ],
-          |  "messages": [],
-          |  "result": null
-          |}
-        """.stripMargin)
-
       val accountDoesNotExist = Failure(Status.NotFound,
-        """{
-          |  "success": false,
-          |  "errors": [
-          |    {
-          |      "code": 1003,
-          |      "message": "Account not found"
-          |    }
-          |  ],
-          |  "messages": [],
-          |  "result": null
-          |}
-        """.stripMargin)
+    json"""{
+             "success": false,
+             "errors": [
+               {
+                 "code": 1003,
+                 "message": "Account not found"
+               }
+             ],
+             "messages": [],
+             "result": null
+           }
+        """.noSpaces)
     }
   }
 }

--- a/client/src/test/scala/dwolla/cloudflare/DnsRecordClientSpec.scala
+++ b/client/src/test/scala/dwolla/cloudflare/DnsRecordClientSpec.scala
@@ -13,6 +13,7 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import shapeless.tag.@@
+import io.circe.literal._
 
 class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
 
@@ -29,22 +30,12 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
 
   "Cloudflare API Client lookup" should {
 
-    "accept a domain name and find a Zone ID" in new Setup {
-      private val domain = "dwolla.com"
-
-      private val output = client(getZoneId).getZoneId(domain)
-        .compile.toList.map(_.headOption).unsafeToFuture()
-
-      output must beSome("fake-zone-id").await
-    }
-
     "accept a domain name and return existing record" in new Setup {
       val getDnsRecordsForZone = new FakeCloudflareService(authorization).listRecordsForZone("fake-zone-id", "example.dwolla.com", SampleResponses.Successes.listDnsRecordsWithOneResult())
-      val output = client(getDnsRecordsForZone <+> getZoneId)
+      private val output = client(getDnsRecordsForZone <+> getZoneId)
         .getExistingDnsRecords("example.dwolla.com")
-        .compile.toList.map(_.headOption).unsafeToFuture
 
-      output must beSome(IdentifiedDnsRecord(
+      output.compile.last.unsafeToFuture must beSome(IdentifiedDnsRecord(
         physicalResourceId = tagString[PhysicalResourceIdTag]("https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-resource-id"),
         zoneId = tagString[ZoneIdTag]("fake-zone-id"),
         resourceId = tagString[ResourceIdTag]("fake-resource-id"),
@@ -65,11 +56,10 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
           SampleResponses.Successes.listDnsRecordsWithOneResult(content = content),
           contentFilter = Option(content),
         )
-      val output = client(getDnsRecordsForZone <+> getZoneId)
+      private val output = client(getDnsRecordsForZone <+> getZoneId)
         .getExistingDnsRecords("example.dwolla.com", content = Option(content))
-        .compile.toList.map(_.headOption).unsafeToFuture
 
-      output must beSome(IdentifiedDnsRecord(
+      output.compile.last.unsafeToFuture must beSome(IdentifiedDnsRecord(
         physicalResourceId = tagString[PhysicalResourceIdTag]("https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-resource-id"),
         zoneId = tagString[ZoneIdTag]("fake-zone-id"),
         resourceId = tagString[ResourceIdTag]("fake-resource-id"),
@@ -90,11 +80,9 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
           SampleResponses.Successes.listDnsRecordsWithOneResult(recordType = "A", content = "192.168.0.1"),
           recordTypeFilter = Option(recordType),
         )
-      val output = client(getDnsRecordsForZone <+> getZoneId)
-        .getExistingDnsRecords("example.dwolla.com", recordType = Option(recordType))
-        .compile.toList.map(_.headOption).unsafeToFuture
+      private val output = client(getDnsRecordsForZone <+> getZoneId).getExistingDnsRecords("example.dwolla.com", recordType = Option(recordType))
 
-      output must beSome(IdentifiedDnsRecord(
+      output.compile.last.unsafeToFuture must beSome(IdentifiedDnsRecord(
         physicalResourceId = tagString[PhysicalResourceIdTag]("https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-resource-id"),
         zoneId = tagString[ZoneIdTag]("fake-zone-id"),
         resourceId = tagString[ResourceIdTag]("fake-resource-id"),
@@ -108,19 +96,16 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
 
     "accept a domain name and return None when no matching record exists" in new Setup {
       val getDnsRecordsForZone = new FakeCloudflareService(authorization).listRecordsForZone("fake-zone-id", "example.dwolla.com", SampleResponses.Successes.listDnsRecordsWithNoResults)
-      val output = client(getDnsRecordsForZone <+> getZoneId)
-        .getExistingDnsRecords("example.dwolla.com")
-        .compile.toList.map(_.headOption).unsafeToFuture
+      private val output = client(getDnsRecordsForZone <+> getZoneId).getExistingDnsRecords("example.dwolla.com")
 
-      output must beNone.await
+      output.compile.last.unsafeToFuture must beNone.await
     }
 
     "accept the URI of a DNS record and return it as an IdentifiedDnsRecord" in new Setup {
       private val fakeZoneId = "fake-zone-id"
       private val fakeRecordId = "fake-record-id"
       private val getDnsRecord = new FakeCloudflareService(authorization).getDnsRecordByUri(fakeZoneId, fakeRecordId)
-      private val output = client(getDnsRecord)
-        .getExistingDnsRecord(physicalResourceId(fakeZoneId, fakeRecordId))
+      private val output = client(getDnsRecord).getByUri(physicalResourceId(fakeZoneId, fakeRecordId))
 
       output.compile.toList.unsafeToFuture() must be_==(List(IdentifiedDnsRecord(
         physicalResourceId = tagString[PhysicalResourceIdTag](s"https://api.cloudflare.com/client/v4/zones/$fakeZoneId/dns_records/$fakeRecordId"),
@@ -136,8 +121,7 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
       private val fakeZoneId = "fake-zone-id"
       private val fakeRecordId = "fake-record-id"
       private val getDnsRecord = new FakeCloudflareService(authorization).getDnsRecordByUri(fakeZoneId, fakeRecordId)
-      private val output = client(getDnsRecord)
-        .getExistingDnsRecord(physicalResourceId(fakeZoneId, "different-fake-resource-id"))
+      private val output = client(getDnsRecord).getByUri(physicalResourceId(fakeZoneId, "different-fake-resource-id"))
 
       output.compile.toList.unsafeToFuture() must be_==(List.empty).await
     }
@@ -239,191 +223,191 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
 
     object Successes {
       val getZones =
-        """{
-          |  "result": [
-          |    {
-          |      "id": "fake-zone-id",
-          |      "name": "dwolla.com",
-          |      "status": "active",
-          |      "paused": false,
-          |      "type": "full",
-          |      "development_mode": 0,
-          |      "name_servers": [
-          |        "eric.ns.cloudflare.com",
-          |        "lucy.ns.cloudflare.com"
-          |      ]
-          |    }
-          |  ],
-          |  "result_info": {
-          |    "page": 1,
-          |    "per_page": 20,
-          |    "total_pages": 1,
-          |    "count": 1,
-          |    "total_count": 1
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""{
+             "result": [
+               {
+                 "id": "fake-zone-id",
+                 "name": "dwolla.com",
+                 "status": "active",
+                 "paused": false,
+                 "type": "full",
+                 "development_mode": 0,
+                 "name_servers": [
+                   "eric.ns.cloudflare.com",
+                   "lucy.ns.cloudflare.com"
+                 ]
+               }
+             ],
+             "result_info": {
+               "page": 1,
+               "per_page": 20,
+               "total_pages": 1,
+               "count": 1,
+               "total_count": 1
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
 
       def listDnsRecordsWithOneResult(content: String = "example.dwollalabs.com",
                                       recordType: String = "CNAME") =
-        s"""{
-           |  "result": [
-           |    {
-           |      "id": "fake-resource-id",
-           |      "type": "$recordType",
-           |      "name": "example.dwolla.com",
-           |      "content": "$content",
-           |      "proxiable": true,
-           |      "proxied": true,
-           |      "ttl": 1,
-           |      "locked": false,
-           |      "zone_id": "fake-zone-id",
-           |      "zone_name": "dwolla.com",
-           |      "modified_on": "2016-12-20T18:45:30.268036Z",
-           |      "created_on": "2016-12-20T18:45:30.268036Z",
-           |      "meta": {
-           |        "auto_added": false
-           |      }
-           |    }
-           |  ],
-           |  "result_info": {
-           |    "page": 1,
-           |    "per_page": 20,
-           |    "total_pages": 1,
-           |    "count": 1,
-           |    "total_count": 1
-           |  },
-           |  "success": true,
-           |  "errors": [],
-           |  "messages": []
-           |}""".stripMargin
+     json"""{
+              "result": [
+                {
+                  "id": "fake-resource-id",
+                  "type": $recordType,
+                  "name": "example.dwolla.com",
+                  "content": $content,
+                  "proxiable": true,
+                  "proxied": true,
+                  "ttl": 1,
+                  "locked": false,
+                  "zone_id": "fake-zone-id",
+                  "zone_name": "dwolla.com",
+                  "modified_on": "2016-12-20T18:45:30.268036Z",
+                  "created_on": "2016-12-20T18:45:30.268036Z",
+                  "meta": {
+                    "auto_added": false
+                  }
+                }
+              ],
+              "result_info": {
+                "page": 1,
+                "per_page": 20,
+                "total_pages": 1,
+                "count": 1,
+                "total_count": 1
+              },
+              "success": true,
+              "errors": [],
+              "messages": []
+            }""".noSpaces
 
       val listDnsRecordsWithNoResults =
-        """{
-          |  "result": [],
-          |  "result_info": {
-          |    "page": 1,
-          |    "per_page": 20,
-          |    "total_pages": 0,
-          |    "count": 0,
-          |    "total_count": 0
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""{
+             "result": [],
+             "result_info": {
+               "page": 1,
+               "per_page": 20,
+               "total_pages": 0,
+               "count": 0,
+               "total_count": 0
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
 
       val listDnsRecordsWithManyResults =
-        """{
-          |  "result": [
-          |    {
-          |      "id": "fake-dns-record-id-1",
-          |      "type": "CNAME",
-          |      "name": "example.dwolla.com",
-          |      "content": "example.dwollalabs.com",
-          |      "proxiable": true,
-          |      "proxied": false,
-          |      "ttl": 1,
-          |      "locked": false,
-          |      "zone_id": "fake-zone-id",
-          |      "zone_name": "dwolla.com",
-          |      "modified_on": "2016-12-20T18:45:19.525129Z",
-          |      "created_on": "2016-12-20T18:45:19.525129Z",
-          |      "meta": {
-          |        "auto_added": false
-          |      }
-          |    },
-          |    {
-          |      "id": "fake-dns-record-id-2",
-          |      "type": "CNAME",
-          |      "name": "example.dwolla.com",
-          |      "content": "example2.dwollalabs.com",
-          |      "proxiable": true,
-          |      "proxied": true,
-          |      "ttl": 1,
-          |      "locked": false,
-          |      "zone_id": "fake-zone-id",
-          |      "zone_name": "dwolla.com",
-          |      "modified_on": "2016-12-20T18:45:30.268036Z",
-          |      "created_on": "2016-12-20T18:45:30.268036Z",
-          |      "meta": {
-          |        "auto_added": false
-          |      }
-          |    }
-          |  ],
-          |  "result_info": {
-          |    "page": 1,
-          |    "per_page": 2,
-          |    "total_pages": 1,
-          |    "count": 2,
-          |    "total_count": 2
-          |  },
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": []
-          |}
-        """.stripMargin
+    json"""{
+             "result": [
+               {
+                 "id": "fake-dns-record-id-1",
+                 "type": "CNAME",
+                 "name": "example.dwolla.com",
+                 "content": "example.dwollalabs.com",
+                 "proxiable": true,
+                 "proxied": false,
+                 "ttl": 1,
+                 "locked": false,
+                 "zone_id": "fake-zone-id",
+                 "zone_name": "dwolla.com",
+                 "modified_on": "2016-12-20T18:45:19.525129Z",
+                 "created_on": "2016-12-20T18:45:19.525129Z",
+                 "meta": {
+                   "auto_added": false
+                 }
+               },
+               {
+                 "id": "fake-dns-record-id-2",
+                 "type": "CNAME",
+                 "name": "example.dwolla.com",
+                 "content": "example2.dwollalabs.com",
+                 "proxiable": true,
+                 "proxied": true,
+                 "ttl": 1,
+                 "locked": false,
+                 "zone_id": "fake-zone-id",
+                 "zone_name": "dwolla.com",
+                 "modified_on": "2016-12-20T18:45:30.268036Z",
+                 "created_on": "2016-12-20T18:45:30.268036Z",
+                 "meta": {
+                   "auto_added": false
+                 }
+               }
+             ],
+             "result_info": {
+               "page": 1,
+               "per_page": 2,
+               "total_pages": 1,
+               "count": 2,
+               "total_count": 2
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }
+        """.noSpaces
 
       val createDnsRecord =
-        """{
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": [],
-          |  "result": {
-          |    "id": "fake-record-id",
-          |    "type": "CNAME",
-          |    "name": "example.dwollalabs.com",
-          |    "content": "example.dwollalabs.com",
-          |    "proxiable": true,
-          |    "proxied": true,
-          |    "ttl": 1,
-          |    "locked": false,
-          |    "zone_id": "fake-zone-id",
-          |    "zone_name": "dwolla.com",
-          |    "created_on": "2014-01-01T05:20:00.12345Z",
-          |    "modified_on": "2014-01-01T05:20:00.12345Z",
-          |    "data": {}
-          |  }
-          |}
-        """.stripMargin
+    json"""{
+             "success": true,
+             "errors": [],
+             "messages": [],
+             "result": {
+               "id": "fake-record-id",
+               "type": "CNAME",
+               "name": "example.dwollalabs.com",
+               "content": "example.dwollalabs.com",
+               "proxiable": true,
+               "proxied": true,
+               "ttl": 1,
+               "locked": false,
+               "zone_id": "fake-zone-id",
+               "zone_name": "dwolla.com",
+               "created_on": "2014-01-01T05:20:00.12345Z",
+               "modified_on": "2014-01-01T05:20:00.12345Z",
+               "data": {}
+             }
+           }
+        """.noSpaces
 
       val updateDnsRecord =
-        """{
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": [],
-          |  "result": {
-          |    "id": "fake-record-id",
-          |    "type": "CNAME",
-          |    "name": "example.dwolla.com",
-          |    "content": "new-content.dwollalabs.com",
-          |    "proxiable": true,
-          |    "proxied": false,
-          |    "ttl": 1,
-          |    "locked": false,
-          |    "zone_id": "fake-zone-id",
-          |    "zone_name": "dwolla.com",
-          |    "created_on": "2014-01-01T05:20:00.12345Z",
-          |    "modified_on": "2014-01-01T05:20:00.12345Z",
-          |    "data": {}
-          |  }
-          |}
-        """.stripMargin
+    json"""{
+             "success": true,
+             "errors": [],
+             "messages": [],
+             "result": {
+               "id": "fake-record-id",
+               "type": "CNAME",
+               "name": "example.dwolla.com",
+               "content": "new-content.dwollalabs.com",
+               "proxiable": true,
+               "proxied": false,
+               "ttl": 1,
+               "locked": false,
+               "zone_id": "fake-zone-id",
+               "zone_name": "dwolla.com",
+               "created_on": "2014-01-01T05:20:00.12345Z",
+               "modified_on": "2014-01-01T05:20:00.12345Z",
+               "data": {}
+             }
+           }
+        """.noSpaces
 
       val deleteDnsRecord =
-        """{
-          |  "success": true,
-          |  "errors": [],
-          |  "messages": [],
-          |  "result": {
-          |    "id": "fake-record-id"
-          |  }
-          |}
-        """.stripMargin
+    json"""{
+             "success": true,
+             "errors": [],
+             "messages": [],
+             "result": {
+               "id": "fake-record-id"
+             }
+           }
+        """.noSpaces
     }
 
     object Failures {
@@ -431,38 +415,38 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
       case class Failure(statusCode: Int, json: String)
 
       val deleteDnsRecordButIdDoesNotExist = Failure(400,
-        """{
-          |  "success": false,
-          |  "errors": [
-          |    {
-          |      "code": 1032,
-          |      "message": "Invalid DNS record identifier"
-          |    }
-          |  ],
-          |  "messages": [],
-          |  "result": null
-          |}
-        """.stripMargin)
+    json"""{
+             "success": false,
+             "errors": [
+               {
+                 "code": 1032,
+                 "message": "Invalid DNS record identifier"
+               }
+             ],
+             "messages": [],
+             "result": null
+           }
+        """.noSpaces)
 
       val validationError = Failure(400,
-        """{
-          |    "success": false,
-          |    "errors": [
-          |        {
-          |            "code": 1004,
-          |            "message": "DNS Validation Error",
-          |            "error_chain": [
-          |                {
-          |                    "code": 9021,
-          |                    "message": "Invalid TTL. Must be between 120 and 2,147,483,647 seconds, or 1 for automatic"
-          |                }
-          |            ]
-          |        }
-          |    ],
-          |    "messages": [],
-          |    "result": null
-          |}
-        """.stripMargin)
+    json"""{
+               "success": false,
+               "errors": [
+                   {
+                       "code": 1004,
+                       "message": "DNS Validation Error",
+                       "error_chain": [
+                           {
+                               "code": 9021,
+                               "message": "Invalid TTL. Must be between 120 and 2,147,483,647 seconds, or 1 for automatic"
+                           }
+                       ]
+                   }
+               ],
+               "messages": [],
+               "result": null
+           }
+        """.noSpaces)
     }
 
   }

--- a/client/src/test/scala/dwolla/cloudflare/DnsRecordClientSpec.scala
+++ b/client/src/test/scala/dwolla/cloudflare/DnsRecordClientSpec.scala
@@ -12,9 +12,12 @@ import org.http4s.client.Client
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
+import shapeless.tag.@@
 
 class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
 
+  private def tagString[T](s: String): String @@ T = shapeless.tag[T][String](s)
+  
   trait Setup extends Scope {
     val client = for {
       fakeExecutor ← Reader((fakeService: HttpService[IO]) ⇒ new StreamingCloudflareApiExecutor[IO](Client.fromHttpService(fakeService), authorization))
@@ -42,9 +45,9 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
         .compile.toList.map(_.headOption).unsafeToFuture
 
       output must beSome(IdentifiedDnsRecord(
-        physicalResourceId = "https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-resource-id",
-        zoneId = "fake-zone-id",
-        resourceId = "fake-resource-id",
+        physicalResourceId = tagString[PhysicalResourceIdTag]("https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-resource-id"),
+        zoneId = tagString[ZoneIdTag]("fake-zone-id"),
+        resourceId = tagString[ResourceIdTag]("fake-resource-id"),
         name = "example.dwolla.com",
         content = "example.dwollalabs.com",
         recordType = "CNAME",
@@ -67,9 +70,9 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
         .compile.toList.map(_.headOption).unsafeToFuture
 
       output must beSome(IdentifiedDnsRecord(
-        physicalResourceId = "https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-resource-id",
-        zoneId = "fake-zone-id",
-        resourceId = "fake-resource-id",
+        physicalResourceId = tagString[PhysicalResourceIdTag]("https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-resource-id"),
+        zoneId = tagString[ZoneIdTag]("fake-zone-id"),
+        resourceId = tagString[ResourceIdTag]("fake-resource-id"),
         name = "example.dwolla.com",
         content = content,
         recordType = "CNAME",
@@ -92,9 +95,9 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
         .compile.toList.map(_.headOption).unsafeToFuture
 
       output must beSome(IdentifiedDnsRecord(
-        physicalResourceId = "https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-resource-id",
-        zoneId = "fake-zone-id",
-        resourceId = "fake-resource-id",
+        physicalResourceId = tagString[PhysicalResourceIdTag]("https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-resource-id"),
+        zoneId = tagString[ZoneIdTag]("fake-zone-id"),
+        resourceId = tagString[ResourceIdTag]("fake-resource-id"),
         name = "example.dwolla.com",
         content = "192.168.0.1",
         recordType = "A",
@@ -120,9 +123,9 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
         .getExistingDnsRecord(physicalResourceId(fakeZoneId, fakeRecordId))
 
       output.compile.toList.unsafeToFuture() must be_==(List(IdentifiedDnsRecord(
-        physicalResourceId = s"https://api.cloudflare.com/client/v4/zones/$fakeZoneId/dns_records/$fakeRecordId",
-        zoneId = fakeZoneId,
-        resourceId = fakeRecordId,
+        physicalResourceId = tagString[PhysicalResourceIdTag](s"https://api.cloudflare.com/client/v4/zones/$fakeZoneId/dns_records/$fakeRecordId"),
+        zoneId = tagString[ZoneIdTag](fakeZoneId),
+        resourceId = tagString[ResourceIdTag](fakeRecordId),
         name = "example.hydragents.xyz",
         content = "content.hydragents.xyz",
         recordType = "CNAME",
@@ -158,9 +161,9 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
         .unsafeToFuture()
 
       output must be_==(List(IdentifiedDnsRecord(
-        physicalResourceId = "https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-record-id",
-        zoneId = "fake-zone-id",
-        resourceId = "fake-record-id",
+        physicalResourceId = tagString[PhysicalResourceIdTag]("https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-record-id"),
+        zoneId = tagString[ZoneIdTag]("fake-zone-id"),
+        resourceId = tagString[ResourceIdTag]("fake-record-id"),
         name = "example.dwolla.com",
         content = "example.dwollalabs.com",
         recordType = "CNAME",
@@ -187,22 +190,22 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
     "accept a DNS Record and return it with its new ID" in new Setup {
       val updateDnsRecord = new FakeCloudflareService(authorization).updateRecordInZone("fake-zone-id", "fake-record-id")
       val output = client(updateDnsRecord).updateDnsRecord(IdentifiedDnsRecord(
-        physicalResourceId = "https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-record-id",
+        physicalResourceId = tagString[PhysicalResourceIdTag]("https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-record-id"),
         name = "example.dwolla.com",
         content = "new-content.dwollalabs.com",
         recordType = "CNAME",
-        zoneId = "fake-zone-id",
-        resourceId = "fake-record-id"
+        zoneId = tagString[ZoneIdTag]("fake-zone-id"),
+        resourceId = tagString[ResourceIdTag]("fake-record-id"),
       ))
         .compile.toList.unsafeToFuture()
 
       output must be_==(List(IdentifiedDnsRecord(
-        physicalResourceId = "https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-record-id",
+        physicalResourceId = tagString[PhysicalResourceIdTag]("https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-record-id"),
         name = "example.dwolla.com",
         content = "new-content.dwollalabs.com",
         recordType = "CNAME",
-        zoneId = "fake-zone-id",
-        resourceId = "fake-record-id",
+        zoneId = tagString[ZoneIdTag]("fake-zone-id"),
+        resourceId = tagString[ResourceIdTag]("fake-record-id"),
         ttl = Option(1),
         proxied = Option(false)
       ))).await
@@ -213,10 +216,9 @@ class DnsRecordClientSpec(implicit ee: ExecutionEnv) extends Specification {
     "accept a physical resource id and return the deleted ID" in new Setup {
       val deleteDnsRecord = new FakeCloudflareService(authorization).deleteRecordInZone("fake-zone-id", "fake-record-id")
 
-      val output = client(deleteDnsRecord).deleteDnsRecord("https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-record-id")
-          .compile.toList.map(_.headOption).unsafeToFuture()
+      private val output = client(deleteDnsRecord).deleteDnsRecord("https://api.cloudflare.com/client/v4/zones/fake-zone-id/dns_records/fake-record-id")
 
-      output must beSome("fake-record-id").await
+      output.compile.last.unsafeToFuture() must beSome("fake-record-id").await
     }
 
     "throw an exception if the Record ID does not exist" in new Setup {

--- a/client/src/test/scala/dwolla/cloudflare/FakeCloudflareService.scala
+++ b/client/src/test/scala/dwolla/cloudflare/FakeCloudflareService.scala
@@ -76,9 +76,9 @@ class FakeCloudflareService(authorization: CloudflareAuthorization) extends Http
   def getDnsRecordByUri(fakeZoneId: String, fakeRecordId: String) = HttpService[IO] {
     case req@GET -> Root / "client" / "v4" / "zones" / zoneId / "dns_records" / recordId if zoneId == fakeZoneId && recordId == fakeRecordId ⇒
       val record: DnsRecord = IdentifiedDnsRecord(
-        physicalResourceId = req.uri.toString(),
-        zoneId = fakeZoneId,
-        resourceId = fakeRecordId,
+        physicalResourceId = shapeless.tag[PhysicalResourceIdTag][String](req.uri.toString()),
+        zoneId = shapeless.tag[ZoneIdTag][String](fakeZoneId),
+        resourceId = shapeless.tag[ResourceIdTag][String](fakeRecordId),
         name = "example.hydragents.xyz",
         content = "content.hydragents.xyz",
         recordType = "CNAME",
@@ -97,8 +97,8 @@ class FakeCloudflareService(authorization: CloudflareAuthorization) extends Http
         result = None,
         success = false,
         errors = Option(List(
-          ResponseInfoDTO(7003, s"Could not route to /zones/$zoneId/dns_records/$recordId, perhaps your object identifier is invalid?"),
-          ResponseInfoDTO(7000, "No route for that URI")
+          ResponseInfoDTO(Option(7003), s"Could not route to /zones/$zoneId/dns_records/$recordId, perhaps your object identifier is invalid?"),
+          ResponseInfoDTO(Option(7000), "No route for that URI")
         )),
         messages = None,
       ).asJson)
@@ -144,7 +144,7 @@ class FakeCloudflareService(authorization: CloudflareAuthorization) extends Http
       BadRequest(ResponseDTO[DnsRecordDTO](
         result = None,
         success = false,
-        errors = Option(List(ResponseInfoDTO(code = 81057, message = "The record already exists."))),
+        errors = Option(List(ResponseInfoDTO(code = Option(81057), message = "The record already exists."))),
         messages = None,
       ).asJson)
   }

--- a/client/src/test/scala/dwolla/cloudflare/ZoneClientSpec.scala
+++ b/client/src/test/scala/dwolla/cloudflare/ZoneClientSpec.scala
@@ -1,0 +1,72 @@
+package dwolla.cloudflare
+
+import cats.data._
+import cats.effect._
+import com.dwolla.cloudflare._
+import com.dwolla.cloudflare.domain.model._
+import org.http4s._
+import org.http4s.client.Client
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import shapeless.tag.@@
+import io.circe.literal._
+
+class ZoneClientSpec(implicit ee: ExecutionEnv) extends Specification {
+  private def tagString[T](s: String): String @@ T = shapeless.tag[T][String](s)
+
+  trait Setup extends Scope {
+    val client = for {
+      fakeExecutor ← Reader((fakeService: HttpService[IO]) ⇒ new StreamingCloudflareApiExecutor[IO](Client.fromHttpService(fakeService), authorization))
+    } yield new ZoneClientImpl(fakeExecutor)
+  }
+
+  val authorization = CloudflareAuthorization("email", "key")
+  val getZoneId = new FakeCloudflareService(authorization).listZones("dwolla.com", SampleResponses.Successes.getZones)
+
+  "ZoneClient" should {
+    "accept a domain name and find a Zone ID" in new Setup {
+      private val domain = "dwolla.com"
+
+      private val output = client(getZoneId).getZoneId(domain)
+
+      output.compile.last.unsafeToFuture must beSome(tagString[ZoneIdTag]("fake-zone-id")).await
+    }
+  }
+
+
+  private object SampleResponses {
+    object Successes {
+      val getZones =
+    json"""{
+             "result": [
+               {
+                 "id": "fake-zone-id",
+                 "name": "dwolla.com",
+                 "status": "active",
+                 "paused": false,
+                 "type": "full",
+                 "development_mode": 0,
+                 "name_servers": [
+                   "eric.ns.cloudflare.com",
+                   "lucy.ns.cloudflare.com"
+                 ]
+               }
+             ],
+             "result_info": {
+               "page": 1,
+               "per_page": 20,
+               "total_pages": 1,
+               "count": 1,
+               "total_count": 1
+             },
+             "success": true,
+             "errors": [],
+             "messages": []
+           }""".noSpaces
+
+    }
+
+  }
+
+}

--- a/dto/src/main/scala/com/dwolla/cloudflare/domain/dto/Response.scala
+++ b/dto/src/main/scala/com/dwolla/cloudflare/domain/dto/Response.scala
@@ -12,7 +12,7 @@ object BaseResponseDTO {
 }
 
 case class ResponseInfoDTO (
-  code: Int,
+  code: Option[Int],
   message: String,
   error_chain: Option[List[ResponseInfoDTO]] = None,
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.4
+sbt.version = 1.2.3


### PR DESCRIPTION
I could use some feedback on the changes I made here, which I think can be grouped into two categories. First, I removed all the calls to `executor.raw` and replaced them with `fetch`, which required some refactoring in how errors were handled (because we were putting endpoint-specific error codes into that global handler before). 

Second, I think I introduced tagged types to all the IDs we have in the library. I think the types are in place but we may need more methods like `RateLimitClient.parseUri` and `RateLimitClient.getByUri` to go from untagged strings to the tagged types.

Definitely looking for feedback in both areas.